### PR TITLE
Code Quality Fixes

### DIFF
--- a/DragonFruit.Common.Data.Tests/Advanced/Objects/DatabaseUpdateRequest.cs
+++ b/DragonFruit.Common.Data.Tests/Advanced/Objects/DatabaseUpdateRequest.cs
@@ -10,9 +10,9 @@ namespace DragonFruit.Common.Data.Tests.Advanced.Objects
     {
         public override string Path => "https://postman-echo.com/post";
 
-        public override Methods Method => Methods.Post;
+        protected override Methods Method => Methods.Post;
 
-        public override DataTypes DataType => DataTypes.SerializedProperty;
+        protected override DataTypes DataType => DataTypes.SerializedProperty;
 
         [RequestBody]
         public Employee Employee { get; set; } = new Employee

--- a/DragonFruit.Common.Data.Tests/Threading/MultiThreadSyncTests.cs
+++ b/DragonFruit.Common.Data.Tests/Threading/MultiThreadSyncTests.cs
@@ -21,7 +21,6 @@ namespace DragonFruit.Common.Data.Tests.Threading
         public void MultiThreadSyncTest()
         {
             var specialClient = new ThreadingApiClient();
-            var echoRequest = new EchoRequest();
             var rng = new Random();
 
             async Task PerformTest()
@@ -29,7 +28,7 @@ namespace DragonFruit.Common.Data.Tests.Threading
                 var headerValue = rng.Next().ToString();
                 specialClient.ChangeHeaders(headerValue);
 
-                var response = specialClient.Perform<JObject>(echoRequest);
+                var response = specialClient.Perform<JObject>(new EchoRequest());
                 Assert.AreEqual(response["headers"]![ThreadingApiClient.HeaderName], headerValue);
             }
 

--- a/DragonFruit.Common.Data/ApiFileRequest.cs
+++ b/DragonFruit.Common.Data/ApiFileRequest.cs
@@ -7,7 +7,7 @@ namespace DragonFruit.Common.Data
 {
     public abstract class ApiFileRequest : ApiRequest
     {
-        public override Methods Method => Methods.Get;
+        protected override Methods Method => Methods.Get;
 
         public abstract string Destination { get; }
 

--- a/DragonFruit.Common.Data/ApiFileRequest.cs
+++ b/DragonFruit.Common.Data/ApiFileRequest.cs
@@ -1,6 +1,8 @@
 ﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
+using System.IO;
+
 namespace DragonFruit.Common.Data
 {
     public abstract class ApiFileRequest : ApiRequest
@@ -8,5 +10,7 @@ namespace DragonFruit.Common.Data
         public override Methods Method => Methods.Get;
 
         public abstract string Destination { get; }
+
+        public virtual FileMode FileCreationMode => FileMode.Create;
     }
 }

--- a/DragonFruit.Common.Data/ApiRequest.cs
+++ b/DragonFruit.Common.Data/ApiRequest.cs
@@ -17,9 +17,9 @@ namespace DragonFruit.Common.Data
     {
         public abstract string Path { get; }
 
-        public virtual Methods Method => Methods.Get;
+        protected virtual Methods Method => Methods.Get;
 
-        public virtual DataTypes DataType { get; }
+        protected virtual DataTypes DataType { get; }
 
         public virtual bool RequireAuth => false;
 

--- a/DragonFruit.Common.Data/ApiRequest.cs
+++ b/DragonFruit.Common.Data/ApiRequest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using DragonFruit.Common.Data.Parameters;
+using DragonFruit.Common.Data.Serializers;
 using Newtonsoft.Json;
 
 namespace DragonFruit.Common.Data
@@ -46,11 +47,16 @@ namespace DragonFruit.Common.Data
             foreach (var property in GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
             {
                 if (!(Attribute.GetCustomAttribute(property, type) is T parameter))
+                {
                     continue;
+                }
 
                 var value = property.GetValue(this, null);
+
                 if (value != null)
+                {
                     yield return new KeyValuePair<string, string>(parameter.Name, value.ToString());
+                }
             }
         }
 
@@ -60,6 +66,74 @@ namespace DragonFruit.Common.Data
                                     .Single(x => Attribute.GetCustomAttribute(x, typeof(T)) is T);
 
             return property.GetValue(this, null);
+        }
+
+        /// <summary>
+        /// Creates the default <see cref="HttpResponseMessage"/>, which can then be overriden by <see cref="SetupRequest"/>
+        /// </summary>
+        internal HttpRequestMessage GetRequest(ISerializer serializer)
+        {
+            var request = new HttpRequestMessage { RequestUri = new Uri(FullUrl) };
+
+            //generic setup
+            switch (Method)
+            {
+                case Methods.Get:
+                    request.Method = HttpMethod.Get;
+                    break;
+
+                case Methods.Post:
+                    request.Method = HttpMethod.Post;
+                    request.Content = GetContent(serializer);
+                    break;
+
+                case Methods.Put:
+                    request.Method = HttpMethod.Put;
+                    request.Content = GetContent(serializer);
+                    break;
+
+                case Methods.Patch:
+                    request.Method = new HttpMethod("PATCH"); //in .NET standard 2 patch isn't implemented...
+                    request.Content = GetContent(serializer);
+                    break;
+
+                case Methods.Delete:
+                    request.Method = HttpMethod.Delete;
+                    request.Content = GetContent(serializer);
+                    break;
+
+                case Methods.Head:
+                    request.Method = HttpMethod.Head;
+                    break;
+
+                default:
+                    throw new NotImplementedException();
+            }
+
+            return request;
+        }
+
+        private HttpContent GetContent(ISerializer serializer)
+        {
+            switch (DataType)
+            {
+                case DataTypes.Encoded:
+                    return new FormUrlEncodedContent(GetParameter<FormParameter>());
+
+                case DataTypes.Serialized:
+                    return serializer.Serialize(this);
+
+                case DataTypes.SerializedProperty:
+                    var body = serializer.Serialize(GetSingleParameterObject<RequestBody>());
+                    return body;
+
+                case DataTypes.Custom:
+                    return BodyContent;
+
+                default:
+                    //todo custom exception - there should have been a datatype specified
+                    throw new ArgumentOutOfRangeException();
+            }
         }
 
         internal ApiRequest Clone() => (ApiRequest)MemberwiseClone();

--- a/DragonFruit.Common.Data/DragonFruit.Common.Data.csproj
+++ b/DragonFruit.Common.Data/DragonFruit.Common.Data.csproj
@@ -13,6 +13,7 @@
     <RepositoryUrl>https://github.com/dragonfruitnetwork/DragonFruit.Common</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>file, api, web, io, framework, dragonfruit, common</PackageTags>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DragonFruit.Common.Data/Helpers/HashableDictionary.cs
+++ b/DragonFruit.Common.Data/Helpers/HashableDictionary.cs
@@ -1,6 +1,7 @@
 ﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -9,7 +10,7 @@ namespace DragonFruit.Common.Data.Helpers
     /// <summary>
     /// A superset of <see cref="T:System.Collections.Generic.Dictionary`2" /> with a hash code function that calculates the hash based on the keys and values inside.
     /// </summary>
-    public class HashableDictionary<TKey, TValue> : Dictionary<TKey, TValue>
+    public class HashableDictionary<TKey, TValue> : Dictionary<TKey, TValue>, IEquatable<HashableDictionary<TKey, TValue>>
     {
         public override int GetHashCode()
         {
@@ -22,6 +23,21 @@ namespace DragonFruit.Common.Data.Helpers
             }
 
             return hash;
+        }
+
+        public bool Equals(HashableDictionary<TKey, TValue> obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && GetHashCode() == obj.GetHashCode();
         }
     }
 }

--- a/DragonFruit.Common.Data/Helpers/HashableDictionary.cs
+++ b/DragonFruit.Common.Data/Helpers/HashableDictionary.cs
@@ -25,7 +25,14 @@ namespace DragonFruit.Common.Data.Helpers
             return hash;
         }
 
-        public bool Equals(HashableDictionary<TKey, TValue> obj)
+        #region IEquatable
+
+        public bool Equals(HashableDictionary<TKey, TValue> other)
+        {
+            return other != null && GetHashCode() == other.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj))
             {
@@ -37,7 +44,14 @@ namespace DragonFruit.Common.Data.Helpers
                 return true;
             }
 
-            return obj.GetType() == GetType() && GetHashCode() == obj.GetHashCode();
+            if (obj.GetType() != GetType())
+            {
+                return false;
+            }
+
+            return Equals((HashableDictionary<TKey, TValue>)obj);
         }
+
+        #endregion
     }
 }

--- a/DragonFruit.Common.Data/Helpers/JsonProcessorExtensions.cs
+++ b/DragonFruit.Common.Data/Helpers/JsonProcessorExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
+#nullable enable
+
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
@@ -8,8 +10,8 @@ namespace DragonFruit.Common.Data.Helpers
 {
     public static class JsonProcessorExtensions
     {
-        public static string GetString(this JObject source, string key, string @default = "") =>
-            (string)GetBase(source, key) ?? @default;
+        public static string GetString(this JObject source, string key, string @default = "") => 
+            (string?)GetBase(source, key) ?? @default;
 
         public static bool GetBool(this JObject source, string key, bool @default = false) =>
             ((bool?)GetBase(source, key)).GetValueOrDefault(@default);
@@ -47,7 +49,7 @@ namespace DragonFruit.Common.Data.Helpers
         public static decimal GetDecimal(this JObject source, string key, decimal @default = 0) =>
             ((decimal?)GetBase(source, key)).GetValueOrDefault(@default);
 
-        public static IEnumerable<T> GetArray<T>(this JObject source, string key)
+        public static IEnumerable<T>? GetArray<T>(this JObject source, string key)
         {
             try
             {
@@ -62,7 +64,7 @@ namespace DragonFruit.Common.Data.Helpers
         /// <summary>
         ///     Gets the value as a <see cref="JToken" /> type from <see cref="source" />, returning null in event of issue.
         /// </summary>
-        private static JToken GetBase(this JObject source, string key)
+        private static JToken? GetBase(this JObject source, string key)
         {
             try
             {

--- a/DragonFruit.Common.Data/Methods.cs
+++ b/DragonFruit.Common.Data/Methods.cs
@@ -28,7 +28,7 @@ namespace DragonFruit.Common.Data
         Serialized,
 
         /// <summary>
-        /// Finds the <see cref="RequestBody"/> marked property and serializes it
+        /// Finds the single <see cref="RequestBody"/>-marked property and serializes it
         /// </summary>
         SerializedProperty,
 

--- a/DragonFruit.Common.Data/Services/FileServices.cs
+++ b/DragonFruit.Common.Data/Services/FileServices.cs
@@ -32,8 +32,9 @@ namespace DragonFruit.Common.Data.Services
             lock (location)
             {
                 if (!File.Exists(location))
-                    throw new FileNotFoundException(
-                        $"The File, {Path.GetFileName(location)}, does not exist in directory, {Path.GetDirectoryName(location)}.");
+                {
+                    throw new FileNotFoundException($"The File, {Path.GetFileName(location)}, does not exist in directory, {Path.GetDirectoryName(location)}.");
+                }
 
                 using (var reader = File.OpenRead(location))
                 using (var textReader = new StreamReader(reader))
@@ -54,8 +55,9 @@ namespace DragonFruit.Common.Data.Services
             lock (location)
             {
                 if (!File.Exists(location))
-                    throw new FileNotFoundException(
-                        $"The File, {Path.GetFileName(location)}, does not exist in directory, {Path.GetDirectoryName(location)}.");
+                {
+                    throw new FileNotFoundException($"The File, {Path.GetFileName(location)}, does not exist in directory, {Path.GetDirectoryName(location)}.");
+                }
 
                 using (var reader = File.OpenRead(location))
                 using (var textReader = new StreamReader(reader))

--- a/DragonFruit.Common.Data/Services/WebServices.cs
+++ b/DragonFruit.Common.Data/Services/WebServices.cs
@@ -23,7 +23,9 @@ namespace DragonFruit.Common.Data.Services
             var client = new HttpClient();
 
             if (!string.IsNullOrWhiteSpace(userAgent))
+            {
                 client.DefaultRequestHeaders.UserAgent.ParseAdd(userAgent);
+            }
 
             return client;
         }
@@ -40,7 +42,9 @@ namespace DragonFruit.Common.Data.Services
             using (var s = client.GetStreamAsync(uri).Result)
             using (var sr = new StreamReader(s))
             using (JsonReader reader = new JsonTextReader(sr))
+            {
                 return serializer.Deserialize<T>(reader);
+            }
         }
 
         /// <summary>
@@ -52,7 +56,9 @@ namespace DragonFruit.Common.Data.Services
         public static T StreamObject<T>(string uri)
         {
             using (var client = new HttpClient())
+            {
                 return StreamObject<T>(uri, client, JsonSerializer.CreateDefault());
+            }
         }
 
         /// <summary>
@@ -67,7 +73,9 @@ namespace DragonFruit.Common.Data.Services
             using (var s = client.GetStreamAsync(uri).Result)
             using (var sr = new StreamReader(s))
             using (JsonReader reader = new JsonTextReader(sr))
+            {
                 return JObject.Load(reader);
+            }
         }
 
         /// <summary>
@@ -78,7 +86,9 @@ namespace DragonFruit.Common.Data.Services
         public static JObject StreamObject(string uri)
         {
             using (var client = new HttpClient())
+            {
                 return StreamObject(uri, client);
+            }
         }
 
         /// <summary>
@@ -93,7 +103,9 @@ namespace DragonFruit.Common.Data.Services
             using (var s = client.PostAsync(uri, content).Result.Content.ReadAsStreamAsync().Result)
             using (var sr = new StreamReader(s))
             using (JsonReader reader = new JsonTextReader(sr))
+            {
                 return JObject.Load(reader);
+            }
         }
 
         /// <summary>
@@ -105,7 +117,9 @@ namespace DragonFruit.Common.Data.Services
         public static JObject PostData(string uri, HttpContent content)
         {
             using (var client = new HttpClient())
+            {
                 return PostData(uri, content, client);
+            }
         }
 
         /// <summary>
@@ -120,7 +134,9 @@ namespace DragonFruit.Common.Data.Services
             using (var s = client.PostAsync(uri, content).Result.Content.ReadAsStreamAsync().Result)
             using (var sr = new StreamReader(s))
             using (JsonReader reader = new JsonTextReader(sr))
+            {
                 return serializer.Deserialize<T>(reader);
+            }
         }
 
         /// <summary>
@@ -132,7 +148,9 @@ namespace DragonFruit.Common.Data.Services
         public static T PostData<T>(string uri, HttpContent content)
         {
             using (var client = new HttpClient())
+            {
                 return PostData<T>(uri, content, client, JsonSerializer.CreateDefault());
+            }
         }
     }
 }


### PR DESCRIPTION
reduce size of apiclient by moving out some of the request-based functions (like `GetRequest`) into the `ApiRequest` class

- fixed a load of code quality issues
- changed access levels of `ApiRequest.Method` and `ApiRequest.DataType`
- added a finalizer for `ApiClient` (although it shouldn't be needed)