### PR TITLE
Add HeaderPreservingRedirectHandler

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -21,7 +21,7 @@ jobs:
           dotnet build -c Debug
 
       - name: Unit Tests
-        run: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=false
+        run: dotnet test -v n
         env:
           orbit_client_id: ${{ secrets.ORBIT_CLIENT_ID }}
           orbit_client_secret: ${{ secrets.ORBIT_CLIENT_SECRET }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -21,7 +21,7 @@ jobs:
           dotnet build -c Release
 
       - name: Unit Tests
-        run: dotnet test
+        run: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=false
         env:
           orbit_client_id: ${{ secrets.ORBIT_CLIENT_ID }}
           orbit_client_secret: ${{ secrets.ORBIT_CLIENT_SECRET }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -21,7 +21,7 @@ jobs:
           dotnet build -c Debug
 
       - name: Unit Tests
-        run: dotnet test -v d
+        run: dotnet test -v m
         env:
           orbit_client_id: ${{ secrets.ORBIT_CLIENT_ID }}
           orbit_client_secret: ${{ secrets.ORBIT_CLIENT_SECRET }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -21,7 +21,7 @@ jobs:
           dotnet build -c Debug
 
       - name: Unit Tests
-        run: dotnet test -v n
+        run: dotnet test -v d
         env:
           orbit_client_id: ${{ secrets.ORBIT_CLIENT_ID }}
           orbit_client_secret: ${{ secrets.ORBIT_CLIENT_SECRET }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Build
         run: |
           dotnet restore
-          dotnet build -c Release
+          dotnet build -c Debug
 
       - name: Unit Tests
         run: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=false

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -22,3 +22,6 @@ jobs:
 
       - name: Unit Tests
         run: dotnet test
+        env:
+          orbit_client_id: ${{ secrets.ORBIT_CLIENT_ID }}
+          orbit_client_secret: ${{ secrets.ORBIT_CLIENT_SECRET }}

--- a/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/HeaderPreservingHandlerClient.cs
+++ b/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/HeaderPreservingHandlerClient.cs
@@ -1,0 +1,15 @@
+﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using DragonFruit.Common.Data.Handlers;
+
+namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler
+{
+    public class HeaderPreservingHandlerClient : ApiClient
+    {
+        public HeaderPreservingHandlerClient()
+        {
+            Handler = new HeaderPreservingRedirectHandler();
+        }
+    }
+}

--- a/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/HeaderPreservingHeaderTests.cs
+++ b/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/HeaderPreservingHeaderTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
 using System.Collections.Generic;
-using DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Requests;
+using DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Objects;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler
@@ -18,7 +18,7 @@ namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler
             try
             {
                 //get token
-                var auth = redirectClient.Perform<OrbitAuthResponse>(new AuthRequest());
+                var auth = redirectClient.Perform<BasicOrbitAuthResponse>(new AuthRequest());
                 redirectClient.Authorization = $"{auth.Type} {auth.AccessToken}";
 
                 //user lookups by username = 301. without our HeaderPreservingHandler we'd get a 401

--- a/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/HeaderPreservingHeaderTests.cs
+++ b/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/HeaderPreservingHeaderTests.cs
@@ -1,7 +1,6 @@
 ﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
-using System.Collections.Generic;
 using DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Objects;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -14,20 +13,24 @@ namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler
         public void TestHeaderPreservation()
         {
             var redirectClient = new HeaderPreservingHandlerClient();
+            ApiRequest tokenRequest;
 
             try
             {
-                //get token
-                var auth = redirectClient.Perform<BasicOrbitAuthResponse>(new AuthRequest());
-                redirectClient.Authorization = $"{auth.Type} {auth.AccessToken}";
-
-                //user lookups by username = 301. without our HeaderPreservingHandler we'd get a 401
-                redirectClient.Perform(new OrbitTestUserRequest());
+                tokenRequest = new AuthRequest();
             }
-            catch (KeyNotFoundException)
+            catch
             {
                 Assert.Inconclusive("not able to test due to inaccessible secrets.");
+                return;
             }
+
+            //get auth token
+            var auth = redirectClient.Perform<BasicOrbitAuthResponse>(tokenRequest);
+            redirectClient.Authorization = $"{auth.Type} {auth.AccessToken}";
+
+            //user lookups by username = 301. without our HeaderPreservingHandler we'd get a 401
+            redirectClient.Perform(new OrbitTestUserRequest());
         }
     }
 }

--- a/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/HeaderPreservingHeaderTests.cs
+++ b/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/HeaderPreservingHeaderTests.cs
@@ -13,20 +13,9 @@ namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler
         public void TestHeaderPreservation()
         {
             var redirectClient = new HeaderPreservingHandlerClient();
-            ApiRequest tokenRequest;
-
-            try
-            {
-                tokenRequest = new AuthRequest();
-            }
-            catch
-            {
-                Assert.Inconclusive("not able to test due to inaccessible secrets.");
-                return;
-            }
 
             //get auth token
-            var auth = redirectClient.Perform<BasicOrbitAuthResponse>(tokenRequest);
+            var auth = redirectClient.Perform<BasicOrbitAuthResponse>(new AuthRequest());
             redirectClient.Authorization = $"{auth.Type} {auth.AccessToken}";
 
             //user lookups by username = 301. without our HeaderPreservingHandler we'd get a 401

--- a/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/HeaderPreservingHeaderTests.cs
+++ b/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/HeaderPreservingHeaderTests.cs
@@ -1,7 +1,7 @@
 ﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
-using System.Diagnostics;
+using System;
 using DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Objects;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -21,7 +21,7 @@ namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler
             //for some reason inconclusive assertion returns a fail, so we'll just "pass" this with a nice message for now
             if (request.ClientSecret == null)
             {
-                Debug.WriteLine("Environment Variables not found, skipping test.");
+                Console.WriteLine("Environment Variables not found, skipping test.");
                 return;
             }
 

--- a/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/HeaderPreservingHeaderTests.cs
+++ b/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/HeaderPreservingHeaderTests.cs
@@ -1,6 +1,7 @@
 ﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
+using System.Diagnostics;
 using DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Objects;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -14,7 +15,17 @@ namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler
         {
             var redirectClient = new HeaderPreservingHandlerClient();
 
-            var auth = redirectClient.Perform<BasicOrbitAuthResponse>(new AuthRequest());
+            //get auth token
+            var request = new AuthRequest();
+
+            //for some reason inconclusive assertion returns a fail, so we'll just "pass" this with a nice message for now
+            if (request.ClientSecret == null)
+            {
+                Debug.WriteLine("Environment Variables not found, skipping test.");
+                return;
+            }
+
+            var auth = redirectClient.Perform<BasicOrbitAuthResponse>(request);
             redirectClient.Authorization = $"{auth.Type} {auth.AccessToken}";
 
             //user lookups by username = 301. without our HeaderPreservingHandler we'd get a 401

--- a/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/HeaderPreservingHeaderTests.cs
+++ b/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/HeaderPreservingHeaderTests.cs
@@ -14,7 +14,6 @@ namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler
         {
             var redirectClient = new HeaderPreservingHandlerClient();
 
-            //get auth token
             var auth = redirectClient.Perform<BasicOrbitAuthResponse>(new AuthRequest());
             redirectClient.Authorization = $"{auth.Type} {auth.AccessToken}";
 

--- a/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/HeaderPreservingHeaderTests.cs
+++ b/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/HeaderPreservingHeaderTests.cs
@@ -1,0 +1,33 @@
+﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System.Collections.Generic;
+using DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Requests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler
+{
+    [TestClass]
+    public class HeaderPreservingHeaderTests
+    {
+        [TestMethod]
+        public void TestHeaderPreservation()
+        {
+            var redirectClient = new HeaderPreservingHandlerClient();
+
+            try
+            {
+                //get token
+                var auth = redirectClient.Perform<OrbitAuthResponse>(new AuthRequest());
+                redirectClient.Authorization = $"{auth.Type} {auth.AccessToken}";
+
+                //user lookups by username = 301. without our HeaderPreservingHandler we'd get a 401
+                redirectClient.Perform(new OrbitTestUserRequest());
+            }
+            catch (KeyNotFoundException)
+            {
+                Assert.Inconclusive("not able to test due to inaccessible secrets.");
+            }
+        }
+    }
+}

--- a/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/AuthRequest.cs
+++ b/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/AuthRequest.cs
@@ -1,0 +1,35 @@
+﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using DragonFruit.Common.Data.Parameters;
+
+namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Requests
+{
+    public class AuthRequest : ApiRequest
+    {
+        public override string Path => "https://osu.ppy.sh/oauth/token";
+        protected override Methods Method => Methods.Post;
+        protected override DataTypes DataType => DataTypes.Encoded;
+
+        [FormParameter("grant_type")]
+        public string Grant => "client_credentials";
+
+        [FormParameter("client_id")]
+        public string ClientId => GetEnvironmentVar("orbit_client_id");
+
+        [FormParameter("client_secret")]
+        public string ClientSecret => GetEnvironmentVar("orbit_client_secret");
+
+        private static string GetEnvironmentVar(string var)
+        {
+            var envVar = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? Environment.GetEnvironmentVariable(var, EnvironmentVariableTarget.User) ?? Environment.GetEnvironmentVariable(var, EnvironmentVariableTarget.Machine) ?? Environment.GetEnvironmentVariable(var)
+                : Environment.GetEnvironmentVariable(var);
+
+            return envVar ?? throw new KeyNotFoundException();
+        }
+    }
+}

--- a/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/AuthRequest.cs
+++ b/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/AuthRequest.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using DragonFruit.Common.Data.Parameters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Objects
 {
@@ -29,7 +29,7 @@ namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Objects
                 ? Environment.GetEnvironmentVariable(var, EnvironmentVariableTarget.User) ?? Environment.GetEnvironmentVariable(var, EnvironmentVariableTarget.Machine) ?? Environment.GetEnvironmentVariable(var)
                 : Environment.GetEnvironmentVariable(var);
 
-            return envVar ?? throw new KeyNotFoundException();
+            return envVar ?? throw new AssertInconclusiveException("Environment variable not found");
         }
     }
 }

--- a/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/AuthRequest.cs
+++ b/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/AuthRequest.cs
@@ -29,7 +29,12 @@ namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Objects
                 ? Environment.GetEnvironmentVariable(var, EnvironmentVariableTarget.User) ?? Environment.GetEnvironmentVariable(var, EnvironmentVariableTarget.Machine) ?? Environment.GetEnvironmentVariable(var)
                 : Environment.GetEnvironmentVariable(var);
 
-            return envVar ?? throw new AssertInconclusiveException("Environment variable not found");
+            if (envVar == null)
+            {
+                Assert.Inconclusive("Environment variable not found");
+            }
+
+            return envVar;
         }
     }
 }

--- a/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/AuthRequest.cs
+++ b/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/AuthRequest.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using DragonFruit.Common.Data.Parameters;
 
-namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Requests
+namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Objects
 {
     public class AuthRequest : ApiRequest
     {

--- a/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/AuthRequest.cs
+++ b/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/AuthRequest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Runtime.InteropServices;
 using DragonFruit.Common.Data.Parameters;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Objects
 {
@@ -28,11 +27,6 @@ namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Objects
             var envVar = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? Environment.GetEnvironmentVariable(var, EnvironmentVariableTarget.User) ?? Environment.GetEnvironmentVariable(var, EnvironmentVariableTarget.Machine) ?? Environment.GetEnvironmentVariable(var)
                 : Environment.GetEnvironmentVariable(var);
-
-            if (envVar == null)
-            {
-                Assert.Inconclusive("Environment variable not found");
-            }
 
             return envVar;
         }

--- a/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/BasicOrbitAuthResponse.cs
+++ b/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/BasicOrbitAuthResponse.cs
@@ -3,9 +3,9 @@
 
 using Newtonsoft.Json;
 
-namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Requests
+namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Objects
 {
-    public class OrbitAuthResponse
+    public class BasicOrbitAuthResponse
     {
         [JsonProperty("token_type")]
         public string Type { get; set; }

--- a/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/OrbitAuthResponse.cs
+++ b/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/OrbitAuthResponse.cs
@@ -1,0 +1,16 @@
+﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using Newtonsoft.Json;
+
+namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Requests
+{
+    public class OrbitAuthResponse
+    {
+        [JsonProperty("token_type")]
+        public string Type { get; set; }
+
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; }
+    }
+}

--- a/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/OrbitTestUserRequest.cs
+++ b/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/OrbitTestUserRequest.cs
@@ -1,7 +1,7 @@
 ﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
-namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Requests
+namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Objects
 {
     public class OrbitTestUserRequest : ApiRequest
     {

--- a/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/OrbitTestUserRequest.cs
+++ b/DragonFruit.Common.Data.Tests/Handlers/AuthPreservingHandler/Objects/OrbitTestUserRequest.cs
@@ -1,0 +1,10 @@
+﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+namespace DragonFruit.Common.Data.Tests.Handlers.AuthPreservingHandler.Requests
+{
+    public class OrbitTestUserRequest : ApiRequest
+    {
+        public override string Path => "https://osu.ppy.sh/api/v2/users/papacurry";
+    }
+}

--- a/DragonFruit.Common.Data/ApiClient.cs
+++ b/DragonFruit.Common.Data/ApiClient.cs
@@ -57,9 +57,18 @@ namespace DragonFruit.Common.Data
         public string Authorization { get; set; }
 
         /// <summary>
-        /// Optional <see cref="HttpClient"/> settings sent by the <see cref="HttpClientHandler"/>
+        /// Optional <see cref="HttpClient"/> settings sent by the <see cref="HttpMessageHandler"/>.
+        /// The old <see cref="HttpMessageHandler"/> will be disposed on setting a new one.
         /// </summary>
-        protected HttpClientHandler Handler { get; set; }
+        protected HttpMessageHandler Handler
+        {
+            get => _handler;
+            set
+            {
+                _handler?.Dispose();
+                _handler = value;
+            }
+        }
 
         /// <summary>
         /// Method for getting data
@@ -90,6 +99,8 @@ namespace DragonFruit.Common.Data
 
         private readonly object _clientAdjustmentLock = new object();
         private long _currentRequests;
+
+        private HttpMessageHandler _handler;
 
         /// <summary>
         /// Checksum that determines whether we replace the <see cref="HttpClient"/>
@@ -134,7 +145,7 @@ namespace DragonFruit.Common.Data
 
                 //cleanup current client
                 Client?.Dispose();
-                Client = Handler != null ? new HttpClient(Handler, true) : new HttpClient();
+                Client = Handler != null ? new HttpClient(Handler, false) : new HttpClient();
                 var hasAuthData = !string.IsNullOrEmpty(Authorization);
 
                 if (hasAuthData)

--- a/DragonFruit.Common.Data/ApiRequest.cs
+++ b/DragonFruit.Common.Data/ApiRequest.cs
@@ -35,7 +35,7 @@ namespace DragonFruit.Common.Data
             {
                 var queries = GetParameter<QueryParameter>();
                 return !queries.Any()
-                    ? string.Empty
+                    ? null
                     : $"?{string.Join("&", queries.Select(kvp => $"{kvp.Key}={kvp.Value}"))}";
             }
         }

--- a/DragonFruit.Common.Data/Handlers/HeaderPreservingRedirectHandler.cs
+++ b/DragonFruit.Common.Data/Handlers/HeaderPreservingRedirectHandler.cs
@@ -1,0 +1,133 @@
+﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DragonFruit.Common.Data.Handlers
+{
+    /// <summary>
+    /// <see cref="HttpClient"/> will auto-strip the auth header, even on redirects to the same site.
+    /// This handler "bypasses" this protection if the host is the same. It also supports an inner handler, should you wish to configure one.
+    ///
+    /// <para>
+    /// You should only use this if you know what you're doing
+    /// </para>
+    /// <remarks>
+    /// Built from the responses in https://stackoverflow.com/questions/19491525/httpclient-not-sending-basic-authentication-after-redirect/19493338
+    /// </remarks>
+    /// </summary>
+    public class HeaderPreservingRedirectHandler : DelegatingHandler
+    {
+        public HeaderPreservingRedirectHandler()
+            : this(new HttpClientHandler())
+        {
+        }
+
+        public HeaderPreservingRedirectHandler(HttpMessageHandler innerHandler)
+            : base(innerHandler)
+        {
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<HttpResponseMessage>();
+
+            base.SendAsync(request, cancellationToken)
+                .ContinueWith(t =>
+                {
+                    HttpResponseMessage response;
+
+                    try
+                    {
+                        response = t.Result;
+                    }
+                    catch (Exception e)
+                    {
+                        response = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                        {
+                            ReasonPhrase = e.Message
+                        };
+                    }
+
+                    if (response.StatusCode == HttpStatusCode.MovedPermanently
+                        || response.StatusCode == HttpStatusCode.Moved
+                        || response.StatusCode == HttpStatusCode.Redirect
+                        || response.StatusCode == HttpStatusCode.Found
+                        || response.StatusCode == HttpStatusCode.SeeOther
+                        || response.StatusCode == HttpStatusCode.RedirectKeepVerb
+                        || response.StatusCode == HttpStatusCode.TemporaryRedirect
+                        || (int)response.StatusCode == 308)
+                    {
+                        var newRequest = CopyRequest(response);
+
+                        if (response.StatusCode == HttpStatusCode.Redirect
+                            || response.StatusCode == HttpStatusCode.Found
+                            || response.StatusCode == HttpStatusCode.SeeOther)
+                        {
+                            newRequest.Content = null;
+                            newRequest.Method = HttpMethod.Get;
+                        }
+
+                        newRequest.RequestUri = response.Headers.Location;
+
+                        base.SendAsync(newRequest, cancellationToken)
+                            .ContinueWith(t2 => tcs.SetResult(t2.Result), cancellationToken);
+                    }
+                    else
+                    {
+                        tcs.SetResult(response);
+                    }
+                }, cancellationToken);
+
+            return tcs.Task;
+        }
+
+        private static HttpRequestMessage CopyRequest(HttpResponseMessage response)
+        {
+            var oldRequest = response.RequestMessage;
+
+            var newRequest = new HttpRequestMessage(oldRequest.Method, oldRequest.RequestUri);
+
+            if (response.Headers.Location != null)
+            {
+                newRequest.RequestUri = response.Headers.Location.IsAbsoluteUri
+                    ? response.Headers.Location
+                    : new Uri(newRequest.RequestUri, response.Headers.Location);
+            }
+
+            foreach (var header in oldRequest.Headers)
+            {
+                if (header.Key.Equals("Authorization", StringComparison.OrdinalIgnoreCase) && !(oldRequest.RequestUri.Host.Equals(newRequest.RequestUri.Host)))
+                {
+                    //do not leak Authorization Header to other hosts
+                    continue;
+                }
+
+                newRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            foreach (var property in oldRequest.Properties)
+            {
+                newRequest.Properties.Add(property);
+            }
+
+            if (response.StatusCode == HttpStatusCode.Redirect
+                || response.StatusCode == HttpStatusCode.Found
+                || response.StatusCode == HttpStatusCode.SeeOther)
+            {
+                newRequest.Content = null;
+                newRequest.Method = HttpMethod.Get;
+            }
+            else if (oldRequest.Content != null)
+            {
+                newRequest.Content = new StreamContent(oldRequest.Content.ReadAsStreamAsync().Result);
+            }
+
+            return newRequest;
+        }
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,16 @@
 # DragonFruit.Common
 
-![CI](https://github.com/dragonfruitnetwork/DragonFruit.Common/workflows/Publish/badge.svg)
+![CI Publish](https://github.com/dragonfruitnetwork/DragonFruit.Common/workflows/Publish/badge.svg)
+![CI Unit Tests](https://github.com/dragonfruitnetwork/DragonFruit.Common/workflows/Unit%20Tests/badge.svg)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/55343888c7e945b3b7d9d4760309ccb4)](https://www.codacy.com/gh/dragonfruitnetwork/DragonFruit.Common?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=dragonfruitnetwork/DragonFruit.Common&amp;utm_campaign=Badge_Grade)
+[![Nuget](https://img.shields.io/nuget/v/DragonFruit.Common.Data)](https://nuget.org/packages/DragonFruit.Common.Data)
+[![Nuget Prerelease](https://img.shields.io/nuget/vpre/DragonFruit.Common.Data)](https://nuget.org/packages/DragonFruit.Common.Data)
+![Nuget Downloads](https://img.shields.io/nuget/dt/DragonFruit.Common.Data)
 [![DragonFruit Discord](https://img.shields.io/discord/482528405292843018?label=Discord&style=popout)](https://discord.gg/VA26u5Z)
 
 ### Overview
-DragonFruit.Common.Data is aimed to reduce code repetition and make common IO-based tasks easier and faster.
+DragonFruit.Common is aimed to reduce code repetition and make common IO-based tasks easier and faster.
+
+### Getting Started
+
+See the [wiki](https://github.com/dragonfruitnetwork/DragonFruit.Common/wiki) to get started.


### PR DESCRIPTION
Added a `HttpMessageHandler` to deal with the edge-case scenario where an api redirect is made to the same site but the auth header has been stripped. Added tests to show this (and it working)

- On changing the `ApiClient`'s handler, the old one is now disposed.
- Updated test workflow to use new secrets
- In the case there are no query strings to return, a `null` response is returned instead of an empty string.