### PR TITLE
Disable autoredirect on httpclienthandlers

### DIFF
--- a/DragonFruit.Common.Data/Handlers/HeaderPreservingRedirectHandler.cs
+++ b/DragonFruit.Common.Data/Handlers/HeaderPreservingRedirectHandler.cs
@@ -28,8 +28,12 @@ namespace DragonFruit.Common.Data.Handlers
         }
 
         public HeaderPreservingRedirectHandler(HttpMessageHandler innerHandler)
-            : base(innerHandler)
         {
+            if (innerHandler is HttpClientHandler clientHandler)
+            {
+                clientHandler.AllowAutoRedirect = false;
+                InnerHandler = clientHandler;
+            }
         }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)


### PR DESCRIPTION
It causes the same 401 error because the redirect is prematurely handled