### PR TITLE
Namespace and ApiClient changes

### DIFF
--- a/DragonFruit.Common.Data.Tests/Advanced/PostRequestTests.cs
+++ b/DragonFruit.Common.Data.Tests/Advanced/PostRequestTests.cs
@@ -15,11 +15,8 @@ namespace DragonFruit.Common.Data.Tests.Advanced
         {
             var request = new DatabaseUpdateRequest();
 
-            var firstResponse = Client.Perform<JObject>(request);
-            Assert.AreEqual(request.Employee.Department, firstResponse["json"].ToObject<Employee>().Department);
-
-            var secondResponse = Client.PerformLast<JObject>();
-            Assert.AreEqual(secondResponse["json"].ToObject<Employee>().Department, firstResponse["json"].ToObject<Employee>().Department);
+            var response = Client.Perform<JObject>(request);
+            Assert.AreEqual(request.Employee.Department, response["json"].ToObject<Employee>().Department);
         }
     }
 }

--- a/DragonFruit.Common.Data/ApiClient.cs
+++ b/DragonFruit.Common.Data/ApiClient.cs
@@ -8,8 +8,9 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using DragonFruit.Common.Data.Exceptions;
-using DragonFruit.Common.Data.Helpers;
+using DragonFruit.Common.Data.Extensions;
 using DragonFruit.Common.Data.Serializers;
+using DragonFruit.Common.Data.Utils;
 
 namespace DragonFruit.Common.Data
 {

--- a/DragonFruit.Common.Data/ApiClient.cs
+++ b/DragonFruit.Common.Data/ApiClient.cs
@@ -230,17 +230,6 @@ namespace DragonFruit.Common.Data
         #endregion
 
         /// <summary>
-        /// Perform an <see cref="ApiRequest"/> with a specified return type.
-        /// </summary>
-        public virtual T Perform<T>(ApiRequest requestData) where T : class
-        {
-            ValidateRequest(requestData);
-            var request = requestData.GetRequest(Serializer);
-
-            return InternalPerform(request, response => ValidateAndProcess<T>(response, request));
-        }
-
-        /// <summary>
         /// Perform a <see cref="ApiRequest"/> that returns the response message. The <see cref="HttpResponseMessage"/> returned cannot be used for reading data, as the underlying <see cref="Task"/> will be disposed.
         /// </summary>
         public virtual HttpResponseMessage Perform(ApiRequest requestData)
@@ -253,6 +242,25 @@ namespace DragonFruit.Common.Data
 
         /// <summary>
         /// Perform a pre-fabricated <see cref="HttpRequestMessage"/>
+        /// </summary>
+        public virtual HttpResponseMessage Perform(HttpRequestMessage request)
+        {
+            return InternalPerform(request, response => response);
+        }
+
+        /// <summary>
+        /// Perform an <see cref="ApiRequest"/> with a specified return type.
+        /// </summary>
+        public virtual T Perform<T>(ApiRequest requestData) where T : class
+        {
+            ValidateRequest(requestData);
+            var request = requestData.GetRequest(Serializer);
+
+            return InternalPerform(request, response => ValidateAndProcess<T>(response, request));
+        }
+
+        /// <summary>
+        /// Perform a pre-fabricated <see cref="HttpRequestMessage"/> and deserialize the result to the specified type
         /// </summary>
         public virtual T Perform<T>(HttpRequestMessage request) where T : class
         {
@@ -295,7 +303,7 @@ namespace DragonFruit.Common.Data
         /// </summary>
         /// <param name="request">The request to perform</param>
         /// <param name="processResult"><see cref="Func{T,TResult}"/> to process the <see cref="HttpResponseMessage"/></param>
-        protected virtual T InternalPerform<T>(HttpRequestMessage request, Func<HttpResponseMessage, T> processResult)
+        protected T InternalPerform<T>(HttpRequestMessage request, Func<HttpResponseMessage, T> processResult)
         {
             //get client and request (disposables)
             var client = GetClient();

--- a/DragonFruit.Common.Data/Extensions/HashExtensions.cs
+++ b/DragonFruit.Common.Data/Extensions/HashExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
-namespace DragonFruit.Common.Data.Helpers
+namespace DragonFruit.Common.Data.Extensions
 {
     public static class HashExtensions
     {

--- a/DragonFruit.Common.Data/Extensions/JsonExtensions.cs
+++ b/DragonFruit.Common.Data/Extensions/JsonExtensions.cs
@@ -6,7 +6,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
-namespace DragonFruit.Common.Data.Helpers
+namespace DragonFruit.Common.Data.Extensions
 {
     public static class JsonExtensions
     {

--- a/DragonFruit.Common.Data/Serializers/ApiXmlSerializer.cs
+++ b/DragonFruit.Common.Data/Serializers/ApiXmlSerializer.cs
@@ -5,7 +5,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
-using DragonFruit.Common.Data.Helpers;
+using DragonFruit.Common.Data.Utils;
 
 namespace DragonFruit.Common.Data.Serializers
 {

--- a/DragonFruit.Common.Data/Utils/DictionaryHelpers.cs
+++ b/DragonFruit.Common.Data/Utils/DictionaryHelpers.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace DragonFruit.Common.Data.Helpers
+namespace DragonFruit.Common.Data.Utils
 {
     internal static class DictionaryHelpers
     {

--- a/DragonFruit.Common.Data/Utils/HashableDictionary.cs
+++ b/DragonFruit.Common.Data/Utils/HashableDictionary.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace DragonFruit.Common.Data.Helpers
+namespace DragonFruit.Common.Data.Utils
 {
     /// <summary>
     /// A superset of <see cref="T:System.Collections.Generic.Dictionary`2" /> with a hash code function that calculates the hash based on the keys and values inside.


### PR DESCRIPTION
- Refactored the `Helpers` class into the correct folders
- Moved the core `ApiClient` code to new function, `InternalPerform`, which can be accessed by inheritors if needed (non-overridable)
- Removed `PerformLast<T>()` due to concurrency issues, and expose the `HttpRequestMessage` in `ValidateAndProcess<T>` instead
- Removed the `virtual` modifiers from `Perform<T>()` and `Perform()` in favour of using `SetupRequest()` and `SetupClient()`