### PR TITLE
Add BasicApiRequest

### DIFF
--- a/DragonFruit.Common.Data.Tests/Basic/BasicRequestTest.cs
+++ b/DragonFruit.Common.Data.Tests/Basic/BasicRequestTest.cs
@@ -1,6 +1,8 @@
 ﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
+using System.Linq;
+using DragonFruit.Common.Data.Extensions;
 using DragonFruit.Common.Data.Tests.Basic.Objects;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -10,7 +12,7 @@ namespace DragonFruit.Common.Data.Tests.Basic
     public class BasicRequestTests : ApiTest
     {
         [TestMethod]
-        public void BasicRequestTest()
+        public void ApiRequestTest()
         {
             var request = new SteamNewsRequest();
 
@@ -18,6 +20,19 @@ namespace DragonFruit.Common.Data.Tests.Basic
             Client.Perform<SteamNewsResponse>(request);
 
             //returns just the response info - i.e a head request where serialization may not be desired
+            Assert.IsTrue(Client.Perform(request).IsSuccessStatusCode);
+        }
+
+        [TestMethod]
+        public void BasicApiRequestTest()
+        {
+            const int itemCount = 15;
+
+            var request = new BasicApiRequest("https://api.steampowered.com/ISteamNews/GetNewsForApp/v0002")
+                          .WithQuery("appid", 359550)
+                          .WithQuery("count", itemCount);
+
+            Assert.AreEqual(itemCount, Client.Perform<SteamNewsResponse>(request).Container.NewsItems.Count());
             Assert.IsTrue(Client.Perform(request).IsSuccessStatusCode);
         }
     }

--- a/DragonFruit.Common.Data/ApiClient.cs
+++ b/DragonFruit.Common.Data/ApiClient.cs
@@ -31,9 +31,9 @@ namespace DragonFruit.Common.Data
             Serializer = new ApiJsonSerializer(culture);
         }
 
-        public ApiClient(ISerializer serializer)
+        public ApiClient(ISerializer serialiser)
         {
-            Serializer = serializer;
+            Serializer = serialiser;
         }
 
         ~ApiClient()

--- a/DragonFruit.Common.Data/ApiRequest.cs
+++ b/DragonFruit.Common.Data/ApiRequest.cs
@@ -4,13 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Reflection;
 using DragonFruit.Common.Data.Exceptions;
 using DragonFruit.Common.Data.Parameters;
 using DragonFruit.Common.Data.Serializers;
+using DragonFruit.Common.Data.Utils;
 using Newtonsoft.Json;
 
 namespace DragonFruit.Common.Data
@@ -19,7 +18,7 @@ namespace DragonFruit.Common.Data
     public abstract class ApiRequest
     {
         /// <summary>
-        /// The Path to the web resource
+        /// The path (including host, protocol and non-standard port) to the web resource
         /// </summary>
         public abstract string Path { get; }
 
@@ -52,11 +51,15 @@ namespace DragonFruit.Common.Data
         /// <summary>
         /// The fully compiled url
         /// </summary>
-        public string FullUrl => Path + QueryString;
+        public string FullUrl => UrlCompiler;
+
+        /// <summary>
+        /// Getter for fully compiled url (internally visible)
+        /// </summary>
+        internal virtual string UrlCompiler => Path + QueryString;
 
         /// <summary>
         /// Overridable property for configuring a custom body for this request
-        ///
         /// <para>
         /// Only used when the <see cref="BodyType"/> is equal to <see cref="BodyType.Custom"/>
         /// </para>
@@ -64,57 +67,23 @@ namespace DragonFruit.Common.Data
         protected virtual HttpContent BodyContent { get; }
 
         /// <summary>
-        /// <see cref="CultureInfo"/> used for ToString() conversions when collecting attributed members
+        /// Overridable culture for serialising requests.
+        /// Defaults to <see cref="CultureUtils.DefaultCulture"/>
         /// </summary>
-        protected virtual CultureInfo Culture => CultureInfo.InvariantCulture;
+        protected virtual CultureInfo RequestCulture => CultureUtils.DefaultCulture;
 
-        internal string QueryString
-        {
-            get
-            {
-                var queries = GetParameter<QueryParameter>();
-                return !queries.Any()
-                    ? null
-                    : $"?{string.Join("&", queries.Select(kvp => $"{kvp.Key}={kvp.Value}"))}";
-            }
-        }
+        /// <summary>
+        /// Query string generated from all filled <see cref="QueryParameter"/>-attributed properties
+        /// </summary>
+        internal string QueryString => QueryUtils.QueryStringFrom(ParameterUtils.GetParameter<QueryParameter>(this, RequestCulture));
 
-        internal IEnumerable<KeyValuePair<string, string>> GetParameter<T>() where T : IProperty
-        {
-            var type = typeof(T);
-
-            foreach (var property in GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
-            {
-                if (!(Attribute.GetCustomAttribute(property, type) is T parameter))
-                {
-                    continue;
-                }
-
-                var value = property.GetValue(this, null);
-                string convertedValue = value switch
-                {
-                    bool boolVar => boolVar.ToString().ToLower(Culture),
-                    null => null,
-
-                    _ => value.ToString()
-                };
-
-                if (convertedValue != null)
-                {
-                    yield return new KeyValuePair<string, string>(parameter.Name, convertedValue);
-                }
-            }
-        }
-
-        internal object GetSingleParameterObject<T>() where T : Attribute =>
-            GetType().GetProperties()
-                     .Single(x => Attribute.GetCustomAttribute(x, typeof(T)) is T)
-                     .GetValue(this, null);
-
+        /// <summary>
+        /// Create a <see cref="HttpResponseMessage"/> for this <see cref="ApiRequest"/>, which can then be modified manually or overriden by <see cref="ApiClient.SetupRequest"/>
+        /// </summary>
         public HttpRequestMessage Build(ApiClient client) => Build(client.Serializer);
 
         /// <summary>
-        /// Creates a <see cref="HttpResponseMessage"/> for this <see cref="ApiRequest"/>, which can then be modified manually or overriden by <see cref="ApiClient.SetupRequest"/>
+        /// Create a <see cref="HttpResponseMessage"/> for this <see cref="ApiRequest"/>, which can then be modified manually or overriden by <see cref="ApiClient.SetupRequest"/>
         /// </summary>
         /// <remarks>
         /// This validates the <see cref="Path"/> and <see cref="RequireAuth"/> properties, throwing a <see cref="ClientValidationException"/> if it's unsatisfied with the constraints
@@ -167,14 +136,17 @@ namespace DragonFruit.Common.Data
                     throw new NotImplementedException();
             }
 
-            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(serializer.ContentType));
-
             if (Headers.IsValueCreated)
             {
                 foreach (var header in Headers.Value)
                 {
                     request.Headers.Add(header.Key, header.Value);
                 }
+            }
+
+            if (!request.Headers.Contains("Accept"))
+            {
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(serializer.ContentType));
             }
 
             return request;
@@ -185,13 +157,13 @@ namespace DragonFruit.Common.Data
             switch (BodyType)
             {
                 case BodyType.Encoded:
-                    return new FormUrlEncodedContent(GetParameter<FormParameter>());
+                    return new FormUrlEncodedContent(ParameterUtils.GetParameter<FormParameter>(this, RequestCulture));
 
                 case BodyType.Serialized:
                     return serializer.Serialize(this);
 
                 case BodyType.SerializedProperty:
-                    var body = serializer.Serialize(GetSingleParameterObject<RequestBody>());
+                    var body = serializer.Serialize(ParameterUtils.GetSingleParameterObject<RequestBody>(this));
                     return body;
 
                 case BodyType.Custom:

--- a/DragonFruit.Common.Data/ApiRequest.cs
+++ b/DragonFruit.Common.Data/ApiRequest.cs
@@ -88,7 +88,7 @@ namespace DragonFruit.Common.Data
         /// <remarks>
         /// This validates the <see cref="Path"/> and <see cref="RequireAuth"/> properties, throwing a <see cref="ClientValidationException"/> if it's unsatisfied with the constraints
         /// </remarks>
-        public HttpRequestMessage Build(ISerializer serializer)
+        public HttpRequestMessage Build(ISerializer serialiser)
         {
             if (!Path.StartsWith("http"))
             {
@@ -106,22 +106,22 @@ namespace DragonFruit.Common.Data
 
                 case Methods.Post:
                     request.Method = HttpMethod.Post;
-                    request.Content = GetContent(serializer);
+                    request.Content = GetContent(serialiser);
                     break;
 
                 case Methods.Put:
                     request.Method = HttpMethod.Put;
-                    request.Content = GetContent(serializer);
+                    request.Content = GetContent(serialiser);
                     break;
 
                 case Methods.Patch:
                     request.Method = new HttpMethod("PATCH"); //in .NET Standard 2.0 patch isn't implemented...
-                    request.Content = GetContent(serializer);
+                    request.Content = GetContent(serialiser);
                     break;
 
                 case Methods.Delete:
                     request.Method = HttpMethod.Delete;
-                    request.Content = GetContent(serializer);
+                    request.Content = GetContent(serialiser);
                     break;
 
                 case Methods.Head:
@@ -146,13 +146,13 @@ namespace DragonFruit.Common.Data
 
             if (!request.Headers.Contains("Accept"))
             {
-                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(serializer.ContentType));
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(serialiser.ContentType));
             }
 
             return request;
         }
 
-        private HttpContent GetContent(ISerializer serializer)
+        private HttpContent GetContent(ISerializer serialiser)
         {
             switch (BodyType)
             {
@@ -160,10 +160,10 @@ namespace DragonFruit.Common.Data
                     return new FormUrlEncodedContent(ParameterUtils.GetParameter<FormParameter>(this, RequestCulture));
 
                 case BodyType.Serialized:
-                    return serializer.Serialize(this);
+                    return serialiser.Serialize(this);
 
                 case BodyType.SerializedProperty:
-                    var body = serializer.Serialize(ParameterUtils.GetSingleParameterObject<RequestBody>(this));
+                    var body = serialiser.Serialize(ParameterUtils.GetSingleParameterObject<RequestBody>(this));
                     return body;
 
                 case BodyType.Custom:

--- a/DragonFruit.Common.Data/BasicApiRequest.cs
+++ b/DragonFruit.Common.Data/BasicApiRequest.cs
@@ -1,0 +1,32 @@
+﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System;
+using System.Collections.Generic;
+using DragonFruit.Common.Data.Utils;
+
+namespace DragonFruit.Common.Data
+{
+    public class BasicApiRequest : ApiRequest
+    {
+        public override string Path { get; }
+
+        internal override string UrlCompiler => Queries.IsValueCreated
+            ? Path + QueryUtils.QueryStringFrom(Queries.Value)
+            : Path;
+
+        /// <summary>
+        /// Initialises a new <see cref="BasicApiRequest"/> with a path to the resource
+        /// </summary>
+        /// <param name="path"></param>
+        public BasicApiRequest(string path)
+        {
+            Path = path;
+        }
+
+        /// <summary>
+        /// Collection of <see cref="KeyValuePair{TKey,TValue}"/>s to use as a query string
+        /// </summary>
+        public Lazy<List<KeyValuePair<string, string>>> Queries { get; private set; } = new Lazy<List<KeyValuePair<string, string>>>(() => new List<KeyValuePair<string, string>>());
+    }
+}

--- a/DragonFruit.Common.Data/Extensions/BasicRequestExtensions.cs
+++ b/DragonFruit.Common.Data/Extensions/BasicRequestExtensions.cs
@@ -1,0 +1,27 @@
+﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System.Collections.Generic;
+
+namespace DragonFruit.Common.Data.Extensions
+{
+    public static class BasicRequestExtensions
+    {
+        /// <summary>
+        /// Appends a query parameter to the current <see cref="BasicApiRequest"/>
+        /// </summary>
+        public static BasicApiRequest WithQuery(this BasicApiRequest request, string key, object value)
+        {
+            return request.WithQuery(key, value.ToString());
+        }
+
+        /// <summary>
+        /// Appends a query parameter to the current <see cref="BasicApiRequest"/>
+        /// </summary>
+        public static BasicApiRequest WithQuery(this BasicApiRequest request, string key, string value)
+        {
+            request.Queries.Value.Add(new KeyValuePair<string, string>(key, value));
+            return request;
+        }
+    }
+}

--- a/DragonFruit.Common.Data/Serializers/ApiJsonSerializer.cs
+++ b/DragonFruit.Common.Data/Serializers/ApiJsonSerializer.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using DragonFruit.Common.Data.Utils;
 using Newtonsoft.Json;
 
 namespace DragonFruit.Common.Data.Serializers
@@ -13,7 +14,7 @@ namespace DragonFruit.Common.Data.Serializers
     public class ApiJsonSerializer : ISerializer
     {
         public ApiJsonSerializer()
-            : this(CultureInfo.InvariantCulture)
+            : this(CultureUtils.DefaultCulture)
         {
         }
 

--- a/DragonFruit.Common.Data/Serializers/ApiXmlSerializer.cs
+++ b/DragonFruit.Common.Data/Serializers/ApiXmlSerializer.cs
@@ -23,13 +23,13 @@ namespace DragonFruit.Common.Data.Serializers
 
         public T Deserialize<T>(Task<Stream> input) where T : class
         {
-            var serializer = new XmlSerializer(typeof(T));
+            var serialiser = new XmlSerializer(typeof(T));
 
             using (Stream stream = input.Result)
             using (StreamReader sr = new StreamReader(stream))
             using (StringReader stringReader = new StringReader(sr.ReadToEndAsync().Result))
             {
-                return (T)serializer.Deserialize(stringReader);
+                return (T)serialiser.Deserialize(stringReader);
             }
         }
     }

--- a/DragonFruit.Common.Data/Services/FileServices.cs
+++ b/DragonFruit.Common.Data/Services/FileServices.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
 using System.IO;
+using DragonFruit.Common.Data.Utils;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -18,7 +19,7 @@ namespace DragonFruit.Common.Data.Services
         /// <typeparam name="T">Type the data was saved in</typeparam>
         /// <param name="location">Location of the file</param>
         /// <returns>Type with populated data</returns>
-        public static T ReadFile<T>(string location) => ReadFile<T>(location, JsonSerializer.CreateDefault());
+        public static T ReadFile<T>(string location) => ReadFile<T>(location, ServiceUtils.DefaultSerialiser);
 
         /// <summary>
         /// Read data from file as specified type, or return default value if the file doesn't exist
@@ -28,7 +29,7 @@ namespace DragonFruit.Common.Data.Services
         /// <returns>Type with populated data</returns>
         public static T ReadFileOrDefault<T>(string location)
         {
-            return ReadFileOrDefault<T>(location, JsonSerializer.CreateDefault());
+            return ReadFileOrDefault<T>(location, ServiceUtils.DefaultSerialiser);
         }
 
         /// <summary>
@@ -36,11 +37,11 @@ namespace DragonFruit.Common.Data.Services
         /// </summary>
         /// <typeparam name="T">Type the data was saved in</typeparam>
         /// <param name="location">Location of the file</param>
-        /// <param name="serializer">The <see cref="JsonSerializer"/> to use</param>
+        /// <param name="serialiser">The <see cref="JsonSerializer"/> to use</param>
         /// <returns>Type with populated data</returns>
-        public static T ReadFileOrDefault<T>(string location, JsonSerializer serializer)
+        public static T ReadFileOrDefault<T>(string location, JsonSerializer serialiser)
         {
-            return File.Exists(location) ? ReadFile<T>(location, serializer) : default;
+            return File.Exists(location) ? ReadFile<T>(location, serialiser) : default;
         }
 
         /// <summary>
@@ -48,9 +49,9 @@ namespace DragonFruit.Common.Data.Services
         /// </summary>
         /// <typeparam name="T">Type the data was saved in</typeparam>
         /// <param name="location">Location of the file</param>
-        /// <param name="serializer">The <see cref="JsonSerializer"/> to use</param>
+        /// <param name="serialiser">The <see cref="JsonSerializer"/> to use</param>
         /// <returns>Type with populated data</returns>
-        public static T ReadFile<T>(string location, JsonSerializer serializer)
+        public static T ReadFile<T>(string location, JsonSerializer serialiser)
         {
             lock (location)
             {
@@ -63,7 +64,7 @@ namespace DragonFruit.Common.Data.Services
                 using (var textReader = new StreamReader(reader))
                 using (var jsonReader = new JsonTextReader(textReader))
                 {
-                    return serializer.Deserialize<T>(jsonReader);
+                    return serialiser.Deserialize<T>(jsonReader);
                 }
             }
         }
@@ -96,16 +97,15 @@ namespace DragonFruit.Common.Data.Services
         /// </summary>
         /// <param name="location">Location of the file</param>
         /// <param name="data">Data to be written</param>
-        public static void WriteFile<T>(string location, T data) =>
-            WriteFile(location, data, JsonSerializer.CreateDefault());
+        public static void WriteFile<T>(string location, T data) => WriteFile(location, data, ServiceUtils.DefaultSerialiser);
 
         /// <summary>
         /// Writes data to a file. If the file exists then it is overwritten with no notice
         /// </summary>
         /// <param name="location">Location of the file</param>
         /// <param name="data">Data to be written</param>
-        /// <param name="serializer">The <see cref="JsonSerializer"/> to use</param>
-        public static void WriteFile<T>(string location, T data, JsonSerializer serializer)
+        /// <param name="serialiser">The <see cref="JsonSerializer"/> to use</param>
+        public static void WriteFile<T>(string location, T data, JsonSerializer serialiser)
         {
             lock (location)
             {
@@ -113,7 +113,7 @@ namespace DragonFruit.Common.Data.Services
                 using (var textWriter = new StreamWriter(reader))
                 using (var jsonWriter = new JsonTextWriter(textWriter))
                 {
-                    serializer.Serialize(jsonWriter, data);
+                    serialiser.Serialize(jsonWriter, data);
                 }
             }
         }

--- a/DragonFruit.Common.Data/Services/WebServices.cs
+++ b/DragonFruit.Common.Data/Services/WebServices.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Net.Http;
+using DragonFruit.Common.Data.Utils;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -36,14 +37,15 @@ namespace DragonFruit.Common.Data.Services
         /// <typeparam name="T">Type to deserialize the result to</typeparam>
         /// <param name="uri">The Uri containing the resource</param>
         /// <param name="client"><see cref="HttpClient" /> to use when downloading</param>
-        /// <returns>The specified tye <see cref="T" />, with the data converted</returns>
-        public static T StreamObject<T>(string uri, HttpClient client, JsonSerializer serializer)
+        /// <param name="serialiser">The <see cref="JsonSerializer"/> to use when deserialising</param>
+        /// <returns>The specified type <see cref="T" />, with the data converted</returns>
+        public static T StreamObject<T>(string uri, HttpClient client, JsonSerializer serialiser)
         {
             using (var s = client.GetStreamAsync(uri).Result)
             using (var sr = new StreamReader(s))
             using (JsonReader reader = new JsonTextReader(sr))
             {
-                return serializer.Deserialize<T>(reader);
+                return serialiser.Deserialize<T>(reader);
             }
         }
 
@@ -57,7 +59,7 @@ namespace DragonFruit.Common.Data.Services
         {
             using (var client = new HttpClient())
             {
-                return StreamObject<T>(uri, client, JsonSerializer.CreateDefault());
+                return StreamObject<T>(uri, client, ServiceUtils.DefaultSerialiser);
             }
         }
 
@@ -129,13 +131,13 @@ namespace DragonFruit.Common.Data.Services
         /// <param name="content">HttpContent Data</param>
         /// <param name="client">HttpClient to use</param>
         /// <returns>Type containing response data</returns>
-        public static T PostData<T>(string uri, HttpContent content, HttpClient client, JsonSerializer serializer)
+        public static T PostData<T>(string uri, HttpContent content, HttpClient client, JsonSerializer serialiser)
         {
             using (var s = client.PostAsync(uri, content).Result.Content.ReadAsStreamAsync().Result)
             using (var sr = new StreamReader(s))
             using (JsonReader reader = new JsonTextReader(sr))
             {
-                return serializer.Deserialize<T>(reader);
+                return serialiser.Deserialize<T>(reader);
             }
         }
 
@@ -149,7 +151,7 @@ namespace DragonFruit.Common.Data.Services
         {
             using (var client = new HttpClient())
             {
-                return PostData<T>(uri, content, client, JsonSerializer.CreateDefault());
+                return PostData<T>(uri, content, client, ServiceUtils.DefaultSerialiser);
             }
         }
     }

--- a/DragonFruit.Common.Data/Utils/CultureUtils.cs
+++ b/DragonFruit.Common.Data/Utils/CultureUtils.cs
@@ -1,0 +1,12 @@
+﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System.Globalization;
+
+namespace DragonFruit.Common.Data.Utils
+{
+    public static class CultureUtils
+    {
+        public static CultureInfo DefaultCulture { get; set; } = CultureInfo.InvariantCulture;
+    }
+}

--- a/DragonFruit.Common.Data/Utils/ParameterUtils.cs
+++ b/DragonFruit.Common.Data/Utils/ParameterUtils.cs
@@ -1,0 +1,56 @@
+﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using DragonFruit.Common.Data.Parameters;
+
+namespace DragonFruit.Common.Data.Utils
+{
+    public static class ParameterUtils
+    {
+        /// <summary>
+        /// Gets an <see cref="IEnumerable{T}"/> of <see cref="KeyValuePair{TKey,TValue}"/>s from properties with a specified <see cref="IProperty"/>-inheriting attribute.
+        /// </summary>
+        internal static IEnumerable<KeyValuePair<string, string>> GetParameter<T>(object host, CultureInfo culture) where T : IProperty
+        {
+            var type = typeof(T);
+
+            foreach (var property in host.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
+            {
+                if (!(Attribute.GetCustomAttribute(property, type) is T parameter))
+                {
+                    continue;
+                }
+
+                var value = property.GetValue(host, null);
+                string convertedValue = value switch
+                {
+                    bool boolVar => boolVar.ToString().ToLower(culture),
+                    null => null,
+
+                    _ => value.ToString()
+                };
+
+                if (convertedValue != null)
+                {
+                    yield return new KeyValuePair<string, string>(parameter.Name, convertedValue);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the single attibute of its kind from a class.
+        /// </summary>
+        internal static object GetSingleParameterObject<T>(object host) where T : Attribute
+        {
+            return host.GetType()
+                       .GetProperties()
+                       .Single(x => Attribute.GetCustomAttribute(x, typeof(T)) is T)
+                       .GetValue(host, null);
+        }
+    }
+}

--- a/DragonFruit.Common.Data/Utils/QueryUtils.cs
+++ b/DragonFruit.Common.Data/Utils/QueryUtils.cs
@@ -1,0 +1,19 @@
+﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DragonFruit.Common.Data.Utils
+{
+    internal static class QueryUtils
+    {
+        /// <summary>
+        /// Produces a query string from an <see cref="IEnumerable{T}"/> of <see cref="KeyValuePair{TKey,TValue}"/>s
+        /// </summary>
+        public static string QueryStringFrom(IEnumerable<KeyValuePair<string, string>> queries) =>
+            !queries.Any()
+                ? string.Empty
+                : $"?{string.Join("&", queries.Select(kvp => $"{kvp.Key}={kvp.Value}"))}";
+    }
+}

--- a/DragonFruit.Common.Data/Utils/ServiceUtils.cs
+++ b/DragonFruit.Common.Data/Utils/ServiceUtils.cs
@@ -1,0 +1,18 @@
+﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using Newtonsoft.Json;
+
+namespace DragonFruit.Common.Data.Utils
+{
+    public static class ServiceUtils
+    {
+        private static JsonSerializer _serialiser;
+
+        public static JsonSerializer DefaultSerialiser
+        {
+            get => _serialiser ??= JsonSerializer.CreateDefault();
+            set => _serialiser = value;
+        }
+    }
+}


### PR DESCRIPTION
- Adds a new `ApiRequest` class called `BasicApiRequest` (get only for now)
- Moves portions of reflection and string generation to the `Utils` class
- Allows the culture of all requests to be controlled by the static property, `CultureUtils.DefaultCulture` which defaults to the `InvariantCulture`

`BasicApiRequest` usage:
```csharp
var request = new BasicApiRequest("https://api.steampowered.com/ISteamNews/GetNewsForApp/v0002")
              .WithQuery("appid", 359550)
              .WithQuery("count", itemCount);
```