### PR TITLE
Implement collection support for forms and queries

### DIFF
--- a/DragonFruit.Common.Data.Tests/QueryCompilationTests.cs
+++ b/DragonFruit.Common.Data.Tests/QueryCompilationTests.cs
@@ -1,0 +1,44 @@
+﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System.Linq;
+using DragonFruit.Common.Data.Parameters;
+using NUnit.Framework;
+
+namespace DragonFruit.Common.Data.Tests
+{
+    [TestFixture]
+    public class QueryCompilationTests
+    {
+        [TestCase]
+        public void TestQueries()
+        {
+            var query = new TestRequest().FullUrl.Split('?').Last().Split('&');
+
+            for (int i = 0; i < TestRequest.TestDataset.Length; i++)
+            {
+                var testString = TestRequest.TestDataset[i];
+                Assert.IsTrue(query.Contains($"{TestRequest.QueryName}={testString}"));
+                Assert.IsTrue(query.Contains($"{TestRequest.QueryName}[]={testString}"));
+                Assert.IsTrue(query.Contains($"{TestRequest.QueryName}[{i}]={testString}"));
+            }
+        }
+    }
+
+    internal class TestRequest : ApiRequest
+    {
+        internal const string QueryName = "data";
+        internal static string[] TestDataset = { "a", "b", "c" };
+
+        public override string Path => "http://example.com";
+
+        [QueryParameter(QueryName, CollectionConversionMode.Recursive)]
+        public string[] RecursiveData { get; set; } = TestDataset;
+
+        [QueryParameter(QueryName, CollectionConversionMode.Ordered)]
+        public string[] OrderedData { get; set; } = TestDataset;
+
+        [QueryParameter(QueryName, CollectionConversionMode.Unordered)]
+        public string[] UnorderedData { get; set; } = TestDataset;
+    }
+}

--- a/DragonFruit.Common.Data.Tests/QueryCompilationTests.cs
+++ b/DragonFruit.Common.Data.Tests/QueryCompilationTests.cs
@@ -30,7 +30,7 @@ namespace DragonFruit.Common.Data.Tests
     internal class TestRequest : ApiRequest
     {
         internal const string QueryName = "data";
-        internal static string[] TestDataset = { "a", "b", "c" };
+        internal static readonly string[] TestDataset = { "a", "b", "c" };
 
         public override string Path => "http://example.com";
 

--- a/DragonFruit.Common.Data.Tests/QueryCompilationTests.cs
+++ b/DragonFruit.Common.Data.Tests/QueryCompilationTests.cs
@@ -22,6 +22,8 @@ namespace DragonFruit.Common.Data.Tests
                 Assert.IsTrue(query.Contains($"{TestRequest.QueryName}[]={testString}"));
                 Assert.IsTrue(query.Contains($"{TestRequest.QueryName}[{i}]={testString}"));
             }
+
+            Assert.IsTrue(query.Contains($"{TestRequest.QueryName}={string.Join(":", TestRequest.TestDataset)}"));
         }
     }
 
@@ -40,5 +42,8 @@ namespace DragonFruit.Common.Data.Tests
 
         [QueryParameter(QueryName, CollectionConversionMode.Unordered)]
         public string[] UnorderedData { get; set; } = TestDataset;
+
+        [QueryParameter(QueryName, CollectionConversionMode.Concatenated, CollectionSeparator = ":")]
+        public string[] ConcatenatedData { get; set; } = TestDataset;
     }
 }

--- a/DragonFruit.Common.Data/ApiRequest.cs
+++ b/DragonFruit.Common.Data/ApiRequest.cs
@@ -74,7 +74,7 @@ namespace DragonFruit.Common.Data
         /// <summary>
         /// Query string generated from all filled <see cref="QueryParameter"/>-attributed properties
         /// </summary>
-        internal string QueryString => QueryUtils.QueryStringFrom(QueryUtils.QueryDataFrom(this, RequestCulture));
+        internal string QueryString => QueryUtils.QueryStringFrom(ParameterUtils.GetParameter<QueryParameter>(this, RequestCulture));
 
         /// <summary>
         /// Create a <see cref="HttpResponseMessage"/> for this <see cref="ApiRequest"/>, which can then be modified manually or overriden by <see cref="ApiClient.SetupRequest"/>

--- a/DragonFruit.Common.Data/ApiRequest.cs
+++ b/DragonFruit.Common.Data/ApiRequest.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using DragonFruit.Common.Data.Exceptions;
 using DragonFruit.Common.Data.Parameters;
 using DragonFruit.Common.Data.Serializers;
 using DragonFruit.Common.Data.Utils;
@@ -75,7 +74,7 @@ namespace DragonFruit.Common.Data
         /// <summary>
         /// Query string generated from all filled <see cref="QueryParameter"/>-attributed properties
         /// </summary>
-        internal string QueryString => QueryUtils.QueryStringFrom(ParameterUtils.GetParameter<QueryParameter>(this, RequestCulture));
+        internal string QueryString => QueryUtils.QueryStringFrom(QueryUtils.QueryDataFrom(this, RequestCulture));
 
         /// <summary>
         /// Create a <see cref="HttpResponseMessage"/> for this <see cref="ApiRequest"/>, which can then be modified manually or overriden by <see cref="ApiClient.SetupRequest"/>

--- a/DragonFruit.Common.Data/DragonFruit.Common.Data.csproj
+++ b/DragonFruit.Common.Data/DragonFruit.Common.Data.csproj
@@ -23,7 +23,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="12.0.3"/>
+        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DragonFruit.Common.Data/Methods.cs
+++ b/DragonFruit.Common.Data/Methods.cs
@@ -38,4 +38,22 @@ namespace DragonFruit.Common.Data
         /// </summary>
         Custom
     }
+
+    public enum CollectionConversionMode
+    {
+        /// <summary>
+        /// The query name is repeated and a new element created for each (a=1&a=2&a=3)
+        /// </summary>
+        Recursive,
+
+        /// <summary>
+        /// The query name has indexer symbols appended with no order (a[]=1&a[]=2&a[]=3)
+        /// </summary>
+        Unordered,
+
+        /// <summary>
+        /// The query name has indexer symbols appended explicit order inserted (a[0]=1&a[1]=2&a[2]=3)
+        /// </summary>
+        Ordered
+    }
 }

--- a/DragonFruit.Common.Data/Methods.cs
+++ b/DragonFruit.Common.Data/Methods.cs
@@ -54,6 +54,11 @@ namespace DragonFruit.Common.Data
         /// <summary>
         /// The query name has indexer symbols appended explicit order inserted (a[0]=1&a[1]=2&a[2]=3)
         /// </summary>
-        Ordered
+        Ordered,
+
+        /// <summary>
+        /// The query is concatenated with a string and merged with one key (a=1,2,3)
+        /// </summary>
+        Concatenated
     }
 }

--- a/DragonFruit.Common.Data/Parameters/FormParameter.cs
+++ b/DragonFruit.Common.Data/Parameters/FormParameter.cs
@@ -15,18 +15,18 @@ namespace DragonFruit.Common.Data.Parameters
         }
 
         public FormParameter(string name)
-            : this(name, CollectionConversionMode.Unordered)
         {
+            Name = name;
         }
 
         public FormParameter(string name, CollectionConversionMode collectionHandling)
+            : this(name)
         {
-            Name = name;
             CollectionHandling = collectionHandling;
         }
 
         public string? Name { get; set; }
-        public CollectionConversionMode CollectionHandling { get; set; }
+        public CollectionConversionMode? CollectionHandling { get; set; }
 
         public string? CollectionSeparator { get; set; }
     }

--- a/DragonFruit.Common.Data/Parameters/FormParameter.cs
+++ b/DragonFruit.Common.Data/Parameters/FormParameter.cs
@@ -9,10 +9,17 @@ namespace DragonFruit.Common.Data.Parameters
     public class FormParameter : Attribute, IProperty
     {
         public FormParameter(string name)
+            : this(name, CollectionConversionMode.Unordered)
+        {
+        }
+
+        public FormParameter(string name, CollectionConversionMode collectionHandling)
         {
             Name = name;
+            CollectionHandling = collectionHandling;
         }
 
         public string Name { get; }
+        public CollectionConversionMode CollectionHandling { get; }
     }
 }

--- a/DragonFruit.Common.Data/Parameters/FormParameter.cs
+++ b/DragonFruit.Common.Data/Parameters/FormParameter.cs
@@ -3,11 +3,17 @@
 
 using System;
 
+#nullable enable
+
 namespace DragonFruit.Common.Data.Parameters
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]
     public class FormParameter : Attribute, IProperty
     {
+        public FormParameter()
+        {
+        }
+
         public FormParameter(string name)
             : this(name, CollectionConversionMode.Unordered)
         {
@@ -19,7 +25,9 @@ namespace DragonFruit.Common.Data.Parameters
             CollectionHandling = collectionHandling;
         }
 
-        public string Name { get; }
-        public CollectionConversionMode CollectionHandling { get; }
+        public string? Name { get; set; }
+        public CollectionConversionMode CollectionHandling { get; set; }
+
+        public string? CollectionSeparator { get; set; }
     }
 }

--- a/DragonFruit.Common.Data/Parameters/IProperty.cs
+++ b/DragonFruit.Common.Data/Parameters/IProperty.cs
@@ -1,12 +1,16 @@
 ﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
+#nullable enable
+
 namespace DragonFruit.Common.Data.Parameters
 {
     public interface IProperty
     {
-        string Name { get; }
+        string? Name { get; set; }
 
-        CollectionConversionMode CollectionHandling { get; }
+        CollectionConversionMode CollectionHandling { get; set; }
+
+        string? CollectionSeparator { get; set; }
     }
 }

--- a/DragonFruit.Common.Data/Parameters/IProperty.cs
+++ b/DragonFruit.Common.Data/Parameters/IProperty.cs
@@ -9,7 +9,7 @@ namespace DragonFruit.Common.Data.Parameters
     {
         string? Name { get; set; }
 
-        CollectionConversionMode CollectionHandling { get; set; }
+        CollectionConversionMode? CollectionHandling { get; set; }
 
         string? CollectionSeparator { get; set; }
     }

--- a/DragonFruit.Common.Data/Parameters/IProperty.cs
+++ b/DragonFruit.Common.Data/Parameters/IProperty.cs
@@ -6,5 +6,7 @@ namespace DragonFruit.Common.Data.Parameters
     public interface IProperty
     {
         string Name { get; }
+
+        CollectionConversionMode CollectionHandling { get; }
     }
 }

--- a/DragonFruit.Common.Data/Parameters/QueryParameter.cs
+++ b/DragonFruit.Common.Data/Parameters/QueryParameter.cs
@@ -20,6 +20,6 @@ namespace DragonFruit.Common.Data.Parameters
         }
 
         public string Name { get; }
-        public CollectionConversionMode CollectionHandling { get; set; }
+        public CollectionConversionMode CollectionHandling { get; }
     }
 }

--- a/DragonFruit.Common.Data/Parameters/QueryParameter.cs
+++ b/DragonFruit.Common.Data/Parameters/QueryParameter.cs
@@ -9,10 +9,17 @@ namespace DragonFruit.Common.Data.Parameters
     public class QueryParameter : Attribute, IProperty
     {
         public QueryParameter(string name)
+            : this(name, CollectionConversionMode.Unordered)
+        {
+        }
+
+        public QueryParameter(string name, CollectionConversionMode collectionConversionMode)
         {
             Name = name;
+            CollectionHandling = collectionConversionMode;
         }
 
         public string Name { get; }
+        public CollectionConversionMode CollectionHandling { get; set; }
     }
 }

--- a/DragonFruit.Common.Data/Parameters/QueryParameter.cs
+++ b/DragonFruit.Common.Data/Parameters/QueryParameter.cs
@@ -15,18 +15,18 @@ namespace DragonFruit.Common.Data.Parameters
         }
 
         public QueryParameter(string name)
-            : this(name, CollectionConversionMode.Unordered)
         {
+            Name = name;
         }
 
         public QueryParameter(string name, CollectionConversionMode collectionConversionMode)
+            : this(name)
         {
-            Name = name;
             CollectionHandling = collectionConversionMode;
         }
 
         public string? Name { get; set; }
-        public CollectionConversionMode CollectionHandling { get; set; }
+        public CollectionConversionMode? CollectionHandling { get; set; }
         public string? CollectionSeparator { get; set; }
     }
 }

--- a/DragonFruit.Common.Data/Parameters/QueryParameter.cs
+++ b/DragonFruit.Common.Data/Parameters/QueryParameter.cs
@@ -3,11 +3,17 @@
 
 using System;
 
+#nullable enable
+
 namespace DragonFruit.Common.Data.Parameters
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]
     public class QueryParameter : Attribute, IProperty
     {
+        public QueryParameter()
+        {
+        }
+
         public QueryParameter(string name)
             : this(name, CollectionConversionMode.Unordered)
         {
@@ -19,7 +25,8 @@ namespace DragonFruit.Common.Data.Parameters
             CollectionHandling = collectionConversionMode;
         }
 
-        public string Name { get; }
-        public CollectionConversionMode CollectionHandling { get; }
+        public string? Name { get; set; }
+        public CollectionConversionMode CollectionHandling { get; set; }
+        public string? CollectionSeparator { get; set; }
     }
 }

--- a/DragonFruit.Common.Data/Utils/CultureUtils.cs
+++ b/DragonFruit.Common.Data/Utils/CultureUtils.cs
@@ -14,5 +14,13 @@ namespace DragonFruit.Common.Data.Utils
             get => _defaultCulture ?? CultureInfo.InvariantCulture;
             set => _defaultCulture = value;
         }
+
+        internal static string AsString(this object value, CultureInfo culture = null) => value switch
+        {
+            bool boolVar => boolVar.ToString().ToLower(culture ?? DefaultCulture),
+            null => null,
+
+            _ => value.ToString()
+        };
     }
 }

--- a/DragonFruit.Common.Data/Utils/ParameterUtils.cs
+++ b/DragonFruit.Common.Data/Utils/ParameterUtils.cs
@@ -31,7 +31,7 @@ namespace DragonFruit.Common.Data.Utils
                     continue;
                 }
 
-                var convertedValue = property.GetValue(host).AsString();
+                var convertedValue = property.GetValue(host).AsString(culture);
                 if (convertedValue != null)
                     yield return new KeyValuePair<string, string>(parameter.Name, convertedValue);
             }

--- a/DragonFruit.Common.Data/Utils/ParameterUtils.cs
+++ b/DragonFruit.Common.Data/Utils/ParameterUtils.cs
@@ -15,7 +15,7 @@ namespace DragonFruit.Common.Data.Utils
         /// <summary>
         /// Default <see cref="BindingFlags"/> to search for matching properties
         /// </summary>
-        private const BindingFlags DefaultFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+        internal const BindingFlags DefaultFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
 
         /// <summary>
         /// Gets an <see cref="IEnumerable{T}"/> of <see cref="KeyValuePair{TKey,TValue}"/>s from properties with a specified <see cref="IProperty"/>-inheriting attribute.
@@ -31,15 +31,7 @@ namespace DragonFruit.Common.Data.Utils
                     continue;
                 }
 
-                var value = property.GetValue(host, null);
-                string convertedValue = value switch
-                {
-                    bool boolVar => boolVar.ToString().ToLower(culture),
-                    null => null,
-
-                    _ => value.ToString()
-                };
-
+                var convertedValue = property.GetValue(host).AsString();
                 if (convertedValue != null)
                     yield return new KeyValuePair<string, string>(parameter.Name, convertedValue);
             }
@@ -53,7 +45,7 @@ namespace DragonFruit.Common.Data.Utils
             return host.GetType()
                        .GetProperties(DefaultFlags)
                        .Single(x => Attribute.GetCustomAttribute(x, typeof(T)) is T)
-                       .GetValue(host, null);
+                       .GetValue(host);
         }
     }
 }

--- a/DragonFruit.Common.Data/Utils/ParameterUtils.cs
+++ b/DragonFruit.Common.Data/Utils/ParameterUtils.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -22,18 +23,68 @@ namespace DragonFruit.Common.Data.Utils
         /// </summary>
         internal static IEnumerable<KeyValuePair<string, string>> GetParameter<T>(object host, CultureInfo culture) where T : IProperty
         {
-            var type = typeof(T);
-
-            foreach (var property in host.GetType().GetProperties(DefaultFlags))
+            foreach (var property in host.GetType().GetProperties(ParameterUtils.DefaultFlags))
             {
-                if (!(Attribute.GetCustomAttribute(property, type) is T parameter))
+                if (!(Attribute.GetCustomAttribute(property, typeof(T)) is T parameter))
                 {
                     continue;
                 }
 
-                var convertedValue = property.GetValue(host).AsString(culture);
-                if (convertedValue != null)
+                // check if the type we've got is an IEnumerable of anything (in this case object)
+                if (typeof(IEnumerable).IsAssignableFrom(property.PropertyType))
+                {
+                    var values = (IEnumerable)property.GetValue(host);
+
+                    switch (parameter.CollectionHandling)
+                    {
+                        case CollectionConversionMode.Recursive:
+                        {
+                            foreach (var item in values)
+                            {
+                                // return multiple of the same key
+                                yield return new KeyValuePair<string, string>(parameter.Name, item.AsString(culture));
+                            }
+
+                            break;
+                        }
+
+                        case CollectionConversionMode.Unordered:
+                        {
+                            foreach (var item in values)
+                            {
+                                // return multiple suffixed keys
+                                yield return new KeyValuePair<string, string>($"{parameter.Name}[]", item.AsString(culture));
+                            }
+
+                            break;
+                        }
+
+                        // if it's order-explicit we need to use an enumerator as there's no length count
+                        case CollectionConversionMode.Ordered:
+                        {
+                            var counter = 0;
+                            var enumerator = values.GetEnumerator();
+
+                            while (enumerator.MoveNext())
+                            {
+                                // return suffixed version with counter
+                                yield return new KeyValuePair<string, string>($"{parameter.Name}[{counter}]", enumerator.Current.AsString(culture));
+                                counter++;
+                            }
+
+                            break;
+                        }
+
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+                else
+                {
+                    // anything else can just be taken as a single object for now
+                    var convertedValue = property.GetValue(host).AsString(culture);
                     yield return new KeyValuePair<string, string>(parameter.Name, convertedValue);
+                }
             }
         }
 

--- a/DragonFruit.Common.Data/Utils/ParameterUtils.cs
+++ b/DragonFruit.Common.Data/Utils/ParameterUtils.cs
@@ -27,7 +27,7 @@ namespace DragonFruit.Common.Data.Utils
         {
             foreach (var property in host.GetType().GetProperties(DefaultFlags))
             {
-                if (!(Attribute.GetCustomAttribute(property, typeof(T)) is T attribute))
+                if (!property.CanRead || !(Attribute.GetCustomAttribute(property, typeof(T)) is T attribute))
                 {
                     continue;
                 }
@@ -41,8 +41,8 @@ namespace DragonFruit.Common.Data.Utils
                     continue;
                 }
 
-                // check if the type we've got is an IEnumerable of anything (in this case object)
-                if (typeof(IEnumerable).IsAssignableFrom(property.PropertyType))
+                // check if the type we've got is an IEnumerable of anything AND we have a valid collection handler mode
+                if (attribute.CollectionHandling.HasValue && typeof(IEnumerable).IsAssignableFrom(property.PropertyType))
                 {
                     Func<IEnumerable<object>, string, CultureInfo, IEnumerable<KeyValuePair<string, string>>> entityConverter = attribute.CollectionHandling switch
                     {

--- a/DragonFruit.Common.Data/Utils/QueryUtils.cs
+++ b/DragonFruit.Common.Data/Utils/QueryUtils.cs
@@ -1,12 +1,8 @@
 ﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using DragonFruit.Common.Data.Parameters;
 
 namespace DragonFruit.Common.Data.Utils
 {
@@ -18,73 +14,5 @@ namespace DragonFruit.Common.Data.Utils
         public static string QueryStringFrom(IEnumerable<KeyValuePair<string, string>> queries) => !queries.Any()
             ? string.Empty
             : $"?{string.Join("&", queries.Select(kvp => $"{kvp.Key}={kvp.Value}"))}";
-
-        public static IEnumerable<KeyValuePair<string, string>> QueryDataFrom(object host, CultureInfo info)
-        {
-            foreach (var property in host.GetType().GetProperties(ParameterUtils.DefaultFlags))
-            {
-                if (!(Attribute.GetCustomAttribute(property, typeof(QueryParameter)) is QueryParameter parameter))
-                {
-                    continue;
-                }
-
-                // check if the type we've got is an IEnumerable of anything (in this case object)
-                if (typeof(IEnumerable).IsAssignableFrom(property.PropertyType))
-                {
-                    var values = (IEnumerable)property.GetValue(host);
-
-                    switch (parameter.CollectionHandling)
-                    {
-                        case CollectionConversionMode.Recursive:
-                        {
-                            foreach (var item in values)
-                            {
-                                // return multiple of the same key
-                                yield return new KeyValuePair<string, string>(parameter.Name, item.AsString(info));
-                            }
-
-                            break;
-                        }
-
-                        case CollectionConversionMode.Unordered:
-                        {
-                            foreach (var item in values)
-                            {
-                                // return multiple suffixed keys
-                                yield return new KeyValuePair<string, string>($"{parameter.Name}[]", item.AsString(info));
-                            }
-
-                            break;
-                        }
-
-                        // if it's order-explicit we need to use an enumerator as there's no length count
-                        case CollectionConversionMode.Ordered:
-                        {
-                            var counter = 0;
-                            var enumerator = values.GetEnumerator();
-
-                            while (enumerator.MoveNext())
-                            {
-                                // return suffixed version with counter
-                                yield return new KeyValuePair<string, string>($"{parameter.Name}[{counter}]", enumerator.Current.AsString(info));
-                                counter++;
-                            }
-
-                            break;
-                        }
-
-                        default:
-                            throw new ArgumentOutOfRangeException();
-                    }
-                }
-                else
-                {
-                    // anything else can just be taken as a single object for now
-                    var convertedValue = property.GetValue(host).AsString(info);
-                    if (convertedValue != null)
-                        yield return new KeyValuePair<string, string>(parameter.Name, convertedValue);
-                }
-            }
-        }
     }
 }

--- a/DragonFruit.Common.Data/Utils/QueryUtils.cs
+++ b/DragonFruit.Common.Data/Utils/QueryUtils.cs
@@ -1,8 +1,12 @@
 ﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
+using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using DragonFruit.Common.Data.Parameters;
 
 namespace DragonFruit.Common.Data.Utils
 {
@@ -14,5 +18,73 @@ namespace DragonFruit.Common.Data.Utils
         public static string QueryStringFrom(IEnumerable<KeyValuePair<string, string>> queries) => !queries.Any()
             ? string.Empty
             : $"?{string.Join("&", queries.Select(kvp => $"{kvp.Key}={kvp.Value}"))}";
+
+        public static IEnumerable<KeyValuePair<string, string>> QueryDataFrom(object host, CultureInfo info)
+        {
+            foreach (var property in host.GetType().GetProperties(ParameterUtils.DefaultFlags))
+            {
+                if (!(Attribute.GetCustomAttribute(property, typeof(QueryParameter)) is QueryParameter parameter))
+                {
+                    continue;
+                }
+
+                // check if the type we've got is an IEnumerable of anything (in this case object)
+                if (typeof(IEnumerable).IsAssignableFrom(property.PropertyType))
+                {
+                    var values = (IEnumerable)property.GetValue(host);
+
+                    switch (parameter.CollectionHandling)
+                    {
+                        case CollectionConversionMode.Recursive:
+                        {
+                            foreach (var item in values)
+                            {
+                                // return multiple of the same key
+                                yield return new KeyValuePair<string, string>(parameter.Name, item.AsString(info));
+                            }
+
+                            break;
+                        }
+
+                        case CollectionConversionMode.Unordered:
+                        {
+                            foreach (var item in values)
+                            {
+                                // return multiple suffixed keys
+                                yield return new KeyValuePair<string, string>($"{parameter.Name}[]", item.AsString(info));
+                            }
+
+                            break;
+                        }
+
+                        // if it's order-explicit we need to use an enumerator as there's no length count
+                        case CollectionConversionMode.Ordered:
+                        {
+                            var counter = 0;
+                            var enumerator = values.GetEnumerator();
+
+                            while (enumerator.MoveNext())
+                            {
+                                // return suffixed version with counter
+                                yield return new KeyValuePair<string, string>($"{parameter.Name}[{counter}]", enumerator.Current.AsString(info));
+                                counter++;
+                            }
+
+                            break;
+                        }
+
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+                else
+                {
+                    // anything else can just be taken as a single object for now
+                    var convertedValue = property.GetValue(host).AsString(info);
+                    if (convertedValue != null)
+                        yield return new KeyValuePair<string, string>(parameter.Name, convertedValue);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #40

This extends the `QueryParameter` and `FormParameter` by essentially allowing the user to provide a collection (`string[]`, `List<string>`, etc.) and have it converted down to one of 4 forms:

For the examples we will use the set of data { "a", "b", "c" } with the query as `data`:

`CollectionConversionMode.Recursive` -> `?data=a&data=b&data=c`
`CollectionConversionMode.Unordered` -> `?data[]=a&data[]=b&data[]=c`
`CollectionConversionMode.Ordered` -> `?data[0]=a&data[1]=b&data[2]=c`
`CollectionConversionMode.Concatenated` -> `?data=a,b,c` (the delimiter can be selected per-item)

as a `string` inherits `IEnumerable<char>` this is operated on an explicit opt-in basis (if the enum is not provided it will be ignored)

also worth noting this update protects against set-only properties by checking if it can be read before trying