### PR TITLE
exit readlock before processing

### DIFF
--- a/DragonFruit.Common.Data/ApiClient.cs
+++ b/DragonFruit.Common.Data/ApiClient.cs
@@ -285,8 +285,6 @@ namespace DragonFruit.Common.Data
 
                 // flush and return
                 stream.Flush();
-
-                // we're not using this so return anything...
                 return response;
             }
 

--- a/DragonFruit.Common.Data/ApiClient.cs
+++ b/DragonFruit.Common.Data/ApiClient.cs
@@ -269,11 +269,17 @@ namespace DragonFruit.Common.Data
                 // create a buffer for progress reporting
                 var buffer = new byte[request.BufferSize];
                 int count;
+                uint iterations = 0;
 
                 while ((count = networkStream.Read(buffer, 0, buffer.Length)) > 0)
                 {
+                    iterations++;
                     stream.Write(buffer, 0, count);
-                    progressUpdated?.Invoke(stream.Length, response.Content.Headers.ContentLength);
+
+                    if (iterations % 25 == 0)
+                    {
+                        progressUpdated?.Invoke(stream.Length, response.Content.Headers.ContentLength);
+                    }
                 }
 
                 // flush and return

--- a/DragonFruit.Common.Data/ApiClient.cs
+++ b/DragonFruit.Common.Data/ApiClient.cs
@@ -276,7 +276,8 @@ namespace DragonFruit.Common.Data
                     iterations++;
                     stream.Write(buffer, 0, count);
 
-                    if (iterations % 25 == 0)
+                    // check every 50th time to stop bottlenecks
+                    if (iterations % 50 == 0)
                     {
                         progressUpdated?.Invoke(stream.Length, response.Content.Headers.ContentLength);
                     }


### PR DESCRIPTION
should help speed up client recreation if needed and allows for callbacks to re-request the data.