### PR TITLE
Improve progress reporting

### DIFF
--- a/DragonFruit.Common.Data/ApiClient.cs
+++ b/DragonFruit.Common.Data/ApiClient.cs
@@ -276,8 +276,8 @@ namespace DragonFruit.Common.Data
                     iterations++;
                     stream.Write(buffer, 0, count);
 
-                    // check every 50th time to stop bottlenecks
-                    if (iterations % 50 == 0)
+                    // check every 10th time to stop bottlenecks
+                    if (iterations % 10 == 0)
                     {
                         progressUpdated?.Invoke(stream.Length, response.Content.Headers.ContentLength);
                     }

--- a/DragonFruit.Common.Data/ApiClient.cs
+++ b/DragonFruit.Common.Data/ApiClient.cs
@@ -266,6 +266,7 @@ namespace DragonFruit.Common.Data
 #else
                 using var networkStream = response.Content.ReadAsStreamAsync().Result;
 #endif
+
                 // create a buffer for progress reporting
                 var buffer = new byte[request.BufferSize];
                 int count;

--- a/DragonFruit.Common.Data/ApiClient.cs
+++ b/DragonFruit.Common.Data/ApiClient.cs
@@ -269,18 +269,16 @@ namespace DragonFruit.Common.Data
                 // create a buffer for progress reporting
                 var buffer = new byte[request.BufferSize];
                 int count;
-                uint iterations = 0;
+                int iterations = 0;
 
                 while ((count = networkStream.Read(buffer, 0, buffer.Length)) > 0)
                 {
-                    iterations++;
+                    Interlocked.Increment(ref iterations);
                     stream.Write(buffer, 0, count);
 
-                    // check every 10th time to stop bottlenecks
-                    if (iterations % 10 == 0)
-                    {
+                    // check every 10th time to stop bottlenecks (use CompareExchange to stop the int from overflowing from insanely large file downloads)
+                    if (Interlocked.CompareExchange(ref iterations, 0, 10) == 10)
                         progressUpdated?.Invoke(stream.Length, response.Content.Headers.ContentLength);
-                    }
                 }
 
                 // flush and return


### PR DESCRIPTION
decreases the wait count to 10 to allow smoother reporting. also moves to interlocked for integer-changing operations to stop overflow errors in the case of an insanely large file.