### PR TITLE
Reduce serializer overhead

### DIFF
--- a/DragonFruit.Common.Data/ApiRequest.cs
+++ b/DragonFruit.Common.Data/ApiRequest.cs
@@ -119,7 +119,7 @@ namespace DragonFruit.Common.Data
 
             var request = new HttpRequestMessage { RequestUri = new Uri(FullUrl) };
 
-            //generic setup
+            // generic setup
             switch (Method)
             {
                 case Methods.Get:

--- a/DragonFruit.Common.Data/ApiRequest.cs
+++ b/DragonFruit.Common.Data/ApiRequest.cs
@@ -117,7 +117,10 @@ namespace DragonFruit.Common.Data
                 throw new HttpRequestException("The request path is invalid (it must start with http or https)");
             }
 
-            var request = new HttpRequestMessage { RequestUri = new Uri(FullUrl) };
+            var request = new HttpRequestMessage
+            {
+                RequestUri = new Uri(FullUrl)
+            };
 
             // generic setup
             switch (Method)

--- a/DragonFruit.Common.Data/Serializers/ISerializer.cs
+++ b/DragonFruit.Common.Data/Serializers/ISerializer.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Net.Http;
+using System.Text;
 
 namespace DragonFruit.Common.Data.Serializers
 {
@@ -10,7 +11,9 @@ namespace DragonFruit.Common.Data.Serializers
     {
         public string ContentType { get; }
 
-        StringContent Serialize<T>(T input) where T : class;
+        public Encoding Encoding { get; set; }
+
+        HttpContent Serialize<T>(T input) where T : class;
 
         T Deserialize<T>(Stream input) where T : class;
     }

--- a/DragonFruit.Common.Data/Serializers/IntermediateSerializer.cs
+++ b/DragonFruit.Common.Data/Serializers/IntermediateSerializer.cs
@@ -1,0 +1,33 @@
+﻿// DragonFruit.Common Copyright 2021 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System.IO;
+using System.Net.Http;
+using System.Text;
+
+namespace DragonFruit.Common.Data.Serializers
+{
+    /// <summary>
+    /// An <see cref="ISerializer"/> that acts as a proxying layer through a serializer that exposes methods to override/alter.
+    /// </summary>
+    public abstract class IntermediateSerializer : ISerializer
+    {
+        private readonly ISerializer _baseSerializer;
+
+        protected IntermediateSerializer(ISerializer baseSerializer)
+        {
+            _baseSerializer = baseSerializer;
+        }
+
+        public string ContentType => _baseSerializer.ContentType;
+
+        public Encoding Encoding
+        {
+            get => _baseSerializer.Encoding;
+            set => _baseSerializer.Encoding = value;
+        }
+
+        public virtual HttpContent Serialize<T>(T input) where T : class => _baseSerializer.Serialize(input);
+        public virtual T Deserialize<T>(Stream input) where T : class => _baseSerializer.Deserialize<T>(input);
+    }
+}

--- a/DragonFruit.Common.Data/Utils/SerializerUtils.cs
+++ b/DragonFruit.Common.Data/Utils/SerializerUtils.cs
@@ -1,0 +1,28 @@
+﻿// DragonFruit.Common Copyright 2021 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using DragonFruit.Common.Data.Serializers;
+
+namespace DragonFruit.Common.Data.Utils
+{
+    public static class SerializerUtils
+    {
+        public static HttpContent ProcessStream(ISerializer serializer, Stream stream, Encoding encoding)
+        {
+            stream.Seek(0, SeekOrigin.Begin);
+            var content = new StreamContent(stream);
+
+            content.Headers.ContentLength = stream.Length;
+            content.Headers.ContentType = new MediaTypeHeaderValue(serializer.ContentType)
+            {
+                CharSet = encoding.WebName
+            };
+
+            return content;
+        }
+    }
+}


### PR DESCRIPTION
Before this the serializer would create a stringbuilder/whatever, write to that then return a `StringContent`. This object would then convert the string back into a stream, which we could have done directly.

Also added the `Encoding` property to `ISerializer`, and a proxying serializer, `IntermediateSerializer`