### PR TITLE
add .To<T>() extension for responses

### DIFF
--- a/DragonFruit.Common.Data.Tests/Requests/RequestTests.cs
+++ b/DragonFruit.Common.Data.Tests/Requests/RequestTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
 using DragonFruit.Common.Data.Basic;
+using DragonFruit.Common.Data.Extensions;
 using DragonFruit.Common.Data.Tests.Requests.Objects;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -43,6 +44,15 @@ namespace DragonFruit.Common.Data.Tests.Requests
                           .WithQuery("count", 15);
 
             Assert.IsTrue(Client.Perform(request).IsSuccessStatusCode);
+        }
+
+        [TestCase]
+        public void RawStringRequest()
+        {
+            var request = new DatabaseUpdateRequest(Methods.Post);
+            var response = JObject.Parse(Client.Perform(request).To<string>());
+
+            Assert.AreEqual(request.Employee.Department, response["json"].ToObject<Employee>().Department);
         }
     }
 }

--- a/DragonFruit.Common.Data/Extensions/ResponseExtensions.cs
+++ b/DragonFruit.Common.Data/Extensions/ResponseExtensions.cs
@@ -1,0 +1,28 @@
+﻿// DragonFruit.Common Copyright 2021 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System;
+using System.Net.Http;
+
+namespace DragonFruit.Common.Data.Extensions
+{
+    public static class ResponseExtensions
+    {
+        public static T To<T>(this HttpResponseMessage response)
+        {
+            response.EnsureSuccessStatusCode();
+
+            var targetType = typeof(T);
+
+            switch (targetType.IsPrimitive)
+            {
+                case true:
+                case false when targetType == typeof(string):
+                    return (T)Convert.ChangeType(response.Content.ReadAsStringAsync().Result, targetType);
+
+                default:
+                    throw new ArgumentException($"Cannot convert HTTP response to {targetType}. It must be a primitive type or a string", nameof(T));
+            }
+        }
+    }
+}


### PR DESCRIPTION
closes #70 (incl tests)

this new system can be used as follows
```cs
var str = client.Perform(new StringRequest()).To<string>();
```