### PR TITLE
add arraypool support to file downloads and json deserialization

### DIFF
--- a/DragonFruit.Common.Data.Tests/DragonFruit.Common.Data.Tests.csproj
+++ b/DragonFruit.Common.Data.Tests/DragonFruit.Common.Data.Tests.csproj
@@ -12,6 +12,6 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
       <PackageReference Include="NUnit" Version="3.13.2" />
-      <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+      <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     </ItemGroup>
 </Project>

--- a/DragonFruit.Common.Data/DragonFruit.Common.Data.csproj
+++ b/DragonFruit.Common.Data/DragonFruit.Common.Data.csproj
@@ -24,6 +24,7 @@
 
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="System.Buffers" Version="4.5.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
this (although small) optimisation should help with memory pressure on mobile devices and clients that do a lot of downloading (as in lots of files, because a new buffer is created each time)