### PR TITLE
Add serializer resolution

### DIFF
--- a/DragonFruit.Common.Data.Tests/Serializer/SerializerResolverTests.cs
+++ b/DragonFruit.Common.Data.Tests/Serializer/SerializerResolverTests.cs
@@ -1,0 +1,67 @@
+﻿// DragonFruit.Common Copyright 2021 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using DragonFruit.Common.Data.Serializers;
+using NUnit.Framework;
+
+namespace DragonFruit.Common.Data.Tests.Serializer
+{
+    [TestFixture]
+    public class SerializerResolverTests : ApiTest
+    {
+        [SetUp]
+        public void Setup()
+        {
+            SerializerResolver.Register<TestObject, ApiXmlSerializer>();
+            SerializerResolver.Register<AnotherTestObject, DummySerializer>();
+        }
+
+        [Test]
+        public void TestResolution()
+        {
+            Assert.AreEqual(Client.Serializer.Resolve<TestObject>(DataDirection.In).GetType(), typeof(ApiXmlSerializer));
+            Assert.AreEqual(Client.Serializer.Resolve<YetAnotherTestObject>(DataDirection.Out).GetType(), typeof(ApiJsonSerializer));
+        }
+
+        [Test]
+        public void TestRemovalResolution()
+        {
+            Assert.AreEqual(Client.Serializer.Resolve<AnotherTestObject>(DataDirection.In).GetType(), typeof(DummySerializer));
+
+            SerializerResolver.Unregister<AnotherTestObject>();
+
+            Assert.AreEqual(Client.Serializer.Resolve<AnotherTestObject>(DataDirection.In).GetType(), typeof(ApiJsonSerializer));
+        }
+    }
+
+    public class TestObject
+    {
+    }
+
+    public class AnotherTestObject
+    {
+    }
+
+    public class YetAnotherTestObject
+    {
+    }
+
+    public class DummySerializer : ISerializer
+    {
+        public string ContentType { get; }
+        public Encoding Encoding { get; set; }
+
+        public HttpContent Serialize<T>(T input) where T : class
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public T Deserialize<T>(Stream input) where T : class
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/DragonFruit.Common.Data/ApiClient.cs
+++ b/DragonFruit.Common.Data/ApiClient.cs
@@ -44,7 +44,7 @@ namespace DragonFruit.Common.Data
         /// </summary>
         public ApiClient(ISerializer serializer)
         {
-            Serializer = serializer;
+            Serializer.Default = serializer;
             Headers = new HeaderCollection(this);
 
             _lock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
@@ -55,7 +55,6 @@ namespace DragonFruit.Common.Data
         ~ApiClient()
         {
             _lock?.Dispose();
-
             Client?.Dispose();
         }
 
@@ -103,12 +102,12 @@ namespace DragonFruit.Common.Data
         }
 
         /// <summary>
-        /// The <see cref="ISerializer"/> to use when encoding/decoding request and response streams.
+        /// The container for <see cref="ISerializer"/>s. The default serializer can be set at <see cref="SerializerResolver.Default"/>
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="ApiJsonSerializer"/>
         /// </remarks>
-        public ISerializer Serializer { get; set; }
+        public SerializerResolver Serializer { get; } = new();
 
         /// <summary>
         /// <see cref="HttpClient"/> used by these requests.
@@ -354,7 +353,7 @@ namespace DragonFruit.Common.Data
             response.EnsureSuccessStatusCode();
 
             using var stream = response.Content.ReadAsStreamAsync().Result;
-            return Serializer.Deserialize<T>(stream);
+            return Serializer.Resolve<T>(DataDirection.In).Deserialize<T>(stream);
         }
 
         /// <summary>

--- a/DragonFruit.Common.Data/ApiClient.cs
+++ b/DragonFruit.Common.Data/ApiClient.cs
@@ -14,6 +14,8 @@ using DragonFruit.Common.Data.Exceptions;
 using DragonFruit.Common.Data.Headers;
 using DragonFruit.Common.Data.Serializers;
 
+#pragma warning disable 618
+
 namespace DragonFruit.Common.Data
 {
     /// <summary>
@@ -44,8 +46,8 @@ namespace DragonFruit.Common.Data
         /// </summary>
         public ApiClient(ISerializer serializer)
         {
-            Serializer.Default = serializer;
             Headers = new HeaderCollection(this);
+            Serializer = new SerializerResolver(serializer);
 
             _lock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
 
@@ -107,7 +109,7 @@ namespace DragonFruit.Common.Data
         /// <remarks>
         /// Defaults to <see cref="ApiJsonSerializer"/>
         /// </remarks>
-        public SerializerResolver Serializer { get; } = new();
+        public SerializerResolver Serializer { get; }
 
         /// <summary>
         /// <see cref="HttpClient"/> used by these requests.

--- a/DragonFruit.Common.Data/ApiRequest.cs
+++ b/DragonFruit.Common.Data/ApiRequest.cs
@@ -110,7 +110,7 @@ namespace DragonFruit.Common.Data
         /// <remarks>
         /// This validates the <see cref="Path"/> and <see cref="RequireAuth"/> properties, throwing a <see cref="ClientValidationException"/> if it's unsatisfied with the constraints
         /// </remarks>
-        public HttpRequestMessage Build(ISerializer serializer)
+        public HttpRequestMessage Build(SerializerResolver serializer)
         {
             if (!Path.StartsWith("http"))
             {
@@ -176,13 +176,13 @@ namespace DragonFruit.Common.Data
 
             if (!request.Headers.Contains("Accept"))
             {
-                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(serializer.ContentType));
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(serializer.Resolve(GetType(), DataDirection.In).ContentType));
             }
 
             return request;
         }
 
-        private HttpContent GetContent(ISerializer serializer)
+        private HttpContent GetContent(SerializerResolver serializer)
         {
             switch (BodyType)
             {
@@ -190,10 +190,10 @@ namespace DragonFruit.Common.Data
                     return new FormUrlEncodedContent(ParameterUtils.GetParameter<FormParameter>(this, RequestCulture));
 
                 case BodyType.Serialized:
-                    return serializer.Serialize(this);
+                    return serializer.Resolve(GetType(), DataDirection.Out).Serialize(this);
 
                 case BodyType.SerializedProperty:
-                    var body = serializer.Serialize(ParameterUtils.GetSingleParameterObject<RequestBody>(this));
+                    var body = serializer.Resolve(GetType(), DataDirection.Out).Serialize(ParameterUtils.GetSingleParameterObject<RequestBody>(this));
                     return body;
 
                 case BodyType.Custom:

--- a/DragonFruit.Common.Data/DragonFruit.Common.Data.csproj
+++ b/DragonFruit.Common.Data/DragonFruit.Common.Data.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
-        <LangVersion>8</LangVersion>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/DragonFruit.Common.Data/DragonFruit.Common.Data.csproj
+++ b/DragonFruit.Common.Data/DragonFruit.Common.Data.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>8</LangVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/DragonFruit.Common.Data/DragonFruit.Common.Data.csproj.DotSettings
+++ b/DragonFruit.Common.Data/DragonFruit.Common.Data.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp80</s:String></wpf:ResourceDictionary>

--- a/DragonFruit.Common.Data/Serializers/ApiJsonSerializer.cs
+++ b/DragonFruit.Common.Data/Serializers/ApiJsonSerializer.cs
@@ -1,6 +1,7 @@
 ﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
+using System;
 using System.Buffers;
 using System.Globalization;
 using System.IO;
@@ -14,20 +15,21 @@ namespace DragonFruit.Common.Data.Serializers
     public class ApiJsonSerializer : ISerializer
     {
         private Encoding _encoding;
+        private JsonSerializer _serializer;
 
         public string ContentType => "application/json";
 
         /// <summary>
-        /// Creates a <see cref="ApiJsonSerializer"/> using the Default Culture
+        /// Creates a <see cref="ApiJsonSerializer"/> using the default culture
         /// </summary>
         public ApiJsonSerializer()
-            : this(CultureUtils.DefaultCulture)
         {
         }
 
         /// <summary>
         /// Creates a <see cref="ApiJsonSerializer"/> using the specified <see cref="CultureInfo"/>
         /// </summary>
+        [Obsolete("This will be removed in the future, use Serializer.Configure instead")]
         public ApiJsonSerializer(CultureInfo culture, Encoding encoding = null, bool autoDetectEncoding = true)
             : this(new JsonSerializerSettings
             {
@@ -40,6 +42,7 @@ namespace DragonFruit.Common.Data.Serializers
         /// <summary>
         /// Creates a <see cref="ApiJsonSerializer"/> using the specified <see cref="JsonSerializerSettings"/>
         /// </summary>
+        [Obsolete("This will be removed in the future, use Serializer.Configure instead")]
         public ApiJsonSerializer(JsonSerializerSettings settings, Encoding encoding = null, bool autoDetectEncoding = true)
             : this(JsonSerializer.Create(settings), encoding, autoDetectEncoding)
         {
@@ -48,6 +51,7 @@ namespace DragonFruit.Common.Data.Serializers
         /// <summary>
         /// Creates a <see cref="ApiJsonSerializer"/> using the specified <see cref="JsonSerializer"/>
         /// </summary>
+        [Obsolete("This will be removed in the future, use Serializer.Configure instead")]
         public ApiJsonSerializer(JsonSerializer serializer, Encoding encoding = null, bool autoDetectEncoding = true)
             : this(encoding, autoDetectEncoding)
         {
@@ -57,6 +61,7 @@ namespace DragonFruit.Common.Data.Serializers
         /// <summary>
         /// Creates a <see cref="ApiJsonSerializer"/> using the specified <see cref="Encoding"/>
         /// </summary>
+        [Obsolete("This will be removed in the future, use Serializer.Configure instead")]
         private ApiJsonSerializer(Encoding encoding, bool autoDetectEncoding)
         {
             Encoding = encoding;
@@ -69,9 +74,13 @@ namespace DragonFruit.Common.Data.Serializers
             set => _encoding = value;
         }
 
-        public bool AutoDetectEncoding { get; set; }
+        public bool AutoDetectEncoding { get; set; } = true;
 
-        public JsonSerializer Serializer { get; set; }
+        public JsonSerializer Serializer
+        {
+            get => _serializer ??= new JsonSerializer { Culture = CultureUtils.DefaultCulture, Formatting = Formatting.Indented };
+            set => _serializer = value;
+        }
 
         public HttpContent Serialize<T>(T input) where T : class
         {

--- a/DragonFruit.Common.Data/Serializers/ApiJsonSerializer.cs
+++ b/DragonFruit.Common.Data/Serializers/ApiJsonSerializer.cs
@@ -12,12 +12,11 @@ using Newtonsoft.Json;
 
 namespace DragonFruit.Common.Data.Serializers
 {
-    public class ApiJsonSerializer : ISerializer
+    public class ApiJsonSerializer : ApiSerializer
     {
-        private Encoding _encoding;
         private JsonSerializer _serializer;
 
-        public string ContentType => "application/json";
+        public override string ContentType => "application/json";
 
         /// <summary>
         /// Creates a <see cref="ApiJsonSerializer"/> using the default culture
@@ -68,21 +67,13 @@ namespace DragonFruit.Common.Data.Serializers
             AutoDetectEncoding = autoDetectEncoding;
         }
 
-        public Encoding Encoding
-        {
-            get => _encoding ?? Encoding.UTF8;
-            set => _encoding = value;
-        }
-
-        public bool AutoDetectEncoding { get; set; } = true;
-
         public JsonSerializer Serializer
         {
             get => _serializer ??= new JsonSerializer { Culture = CultureUtils.DefaultCulture, Formatting = Formatting.Indented };
             set => _serializer = value;
         }
 
-        public HttpContent Serialize<T>(T input) where T : class
+        public override HttpContent Serialize<T>(T input) where T : class
         {
             var stream = new MemoryStream();
 
@@ -97,7 +88,7 @@ namespace DragonFruit.Common.Data.Serializers
             return SerializerUtils.ProcessStream(this, stream);
         }
 
-        public T Deserialize<T>(Stream input) where T : class
+        public override T Deserialize<T>(Stream input) where T : class
         {
             using var sr = AutoDetectEncoding switch
             {

--- a/DragonFruit.Common.Data/Serializers/ApiSerializer.cs
+++ b/DragonFruit.Common.Data/Serializers/ApiSerializer.cs
@@ -1,0 +1,41 @@
+﻿// DragonFruit.Common Copyright 2021 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System.IO;
+using System.Net.Http;
+using System.Text;
+
+#pragma warning disable 618
+
+namespace DragonFruit.Common.Data.Serializers
+{
+    /// <summary>
+    /// Represents the base of a serializer used by the <see cref="ApiClient"/> and <see cref="ApiRequest"/> classes
+    /// </summary>
+    public abstract class ApiSerializer : ISerializer
+    {
+        private Encoding _encoding;
+
+        /// <summary>
+        /// The content-type header value
+        /// </summary>
+        public abstract string ContentType { get; }
+
+        /// <summary>
+        /// Gets or sets the encoding the <see cref="ApiSerializer"/> uses
+        /// </summary>
+        public Encoding Encoding
+        {
+            get => _encoding ?? Encoding.UTF8;
+            set => _encoding = value;
+        }
+
+        /// <summary>
+        /// Whether deserialization should attempt to automatically detect the encoding used
+        /// </summary>
+        public bool AutoDetectEncoding { get; set; } = true;
+
+        public abstract HttpContent Serialize<T>(T input) where T : class;
+        public abstract T Deserialize<T>(Stream input) where T : class;
+    }
+}

--- a/DragonFruit.Common.Data/Serializers/ApiXmlSerializer.cs
+++ b/DragonFruit.Common.Data/Serializers/ApiXmlSerializer.cs
@@ -10,11 +10,9 @@ using DragonFruit.Common.Data.Utils;
 
 namespace DragonFruit.Common.Data.Serializers
 {
-    public class ApiXmlSerializer : ISerializer
+    public class ApiXmlSerializer : ApiSerializer
     {
-        private Encoding _encoding;
-
-        public string ContentType => "application/xml";
+        public override string ContentType => "application/xml";
 
         public ApiXmlSerializer()
         {
@@ -27,15 +25,7 @@ namespace DragonFruit.Common.Data.Serializers
             AutoDetectEncoding = autoDetectEncoding;
         }
 
-        public Encoding Encoding
-        {
-            get => _encoding ?? Encoding.UTF8;
-            set => _encoding = value;
-        }
-
-        public bool AutoDetectEncoding { get; set; } = true;
-
-        public HttpContent Serialize<T>(T input) where T : class
+        public override HttpContent Serialize<T>(T input) where T : class
         {
             var stream = new MemoryStream();
 
@@ -47,7 +37,7 @@ namespace DragonFruit.Common.Data.Serializers
             return SerializerUtils.ProcessStream(this, stream);
         }
 
-        public T Deserialize<T>(Stream input) where T : class
+        public override T Deserialize<T>(Stream input) where T : class
         {
             var serializer = new XmlSerializer(typeof(T));
             using TextReader reader = AutoDetectEncoding switch

--- a/DragonFruit.Common.Data/Serializers/ApiXmlSerializer.cs
+++ b/DragonFruit.Common.Data/Serializers/ApiXmlSerializer.cs
@@ -1,6 +1,7 @@
 ﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
+using System;
 using System.IO;
 using System.Net.Http;
 using System.Text;
@@ -15,6 +16,11 @@ namespace DragonFruit.Common.Data.Serializers
 
         public string ContentType => "application/xml";
 
+        public ApiXmlSerializer()
+        {
+        }
+
+        [Obsolete("This will be removed in the future, use Serializer.Configure instead")]
         public ApiXmlSerializer(Encoding encoding = null, bool autoDetectEncoding = true)
         {
             Encoding = encoding;
@@ -27,7 +33,7 @@ namespace DragonFruit.Common.Data.Serializers
             set => _encoding = value;
         }
 
-        public bool AutoDetectEncoding { get; set; }
+        public bool AutoDetectEncoding { get; set; } = true;
 
         public HttpContent Serialize<T>(T input) where T : class
         {

--- a/DragonFruit.Common.Data/Serializers/ISerializer.cs
+++ b/DragonFruit.Common.Data/Serializers/ISerializer.cs
@@ -1,12 +1,14 @@
 ﻿// DragonFruit.Common Copyright 2020 DragonFruit Network
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
+using System;
 using System.IO;
 using System.Net.Http;
 using System.Text;
 
 namespace DragonFruit.Common.Data.Serializers
 {
+    [Obsolete("This will be replaced with ApiSerializer in the future.")]
     public interface ISerializer
     {
         public string ContentType { get; }

--- a/DragonFruit.Common.Data/Serializers/IntermediateSerializer.cs
+++ b/DragonFruit.Common.Data/Serializers/IntermediateSerializer.cs
@@ -1,6 +1,7 @@
 ﻿// DragonFruit.Common Copyright 2021 DragonFruit Network
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
+using System;
 using System.IO;
 using System.Net.Http;
 using System.Text;
@@ -14,6 +15,7 @@ namespace DragonFruit.Common.Data.Serializers
     {
         private readonly ISerializer _baseSerializer;
 
+        [Obsolete("This is being replaced with the serializer resolver. It will be removed in the future")]
         protected IntermediateSerializer(ISerializer baseSerializer)
         {
             _baseSerializer = baseSerializer;

--- a/DragonFruit.Common.Data/Serializers/SerializerResolver.cs
+++ b/DragonFruit.Common.Data/Serializers/SerializerResolver.cs
@@ -11,8 +11,17 @@ namespace DragonFruit.Common.Data.Serializers
 {
     public class SerializerResolver
     {
-        private static readonly Dictionary<Type, Type> SerializerMap = new();
-        private static readonly Dictionary<Type, Type> DeserializerMap = new();
+        private static readonly Dictionary<Type, Type> SerializerMap = new Dictionary<Type, Type>();
+        private static readonly Dictionary<Type, Type> DeserializerMap = new Dictionary<Type, Type>();
+
+        /// <summary>
+        /// Initialises a new instance of <see cref="SerializerResolver"/>, providing a default <see cref="ApiSerializer"/>
+        /// </summary>
+        /// <param name="default"></param>
+        internal SerializerResolver(ISerializer @default)
+        {
+            Default = @default;
+        }
 
         /// <summary>
         /// Registers a serializer for the specified type. This applies to all <see cref="ApiClient"/>s
@@ -55,7 +64,7 @@ namespace DragonFruit.Common.Data.Serializers
         }
 
         public ISerializer Default { get; set; }
-        private ConcurrentDictionary<Type, ApiSerializer> SerializerCache { get; } = new();
+        private ConcurrentDictionary<Type, ApiSerializer> SerializerCache { get; } = new ConcurrentDictionary<Type, ApiSerializer>();
 
         /// <summary>
         /// Resolves the <see cref="ApiSerializer"/> for the type provided

--- a/DragonFruit.Common.Data/Serializers/SerializerResolver.cs
+++ b/DragonFruit.Common.Data/Serializers/SerializerResolver.cs
@@ -1,0 +1,128 @@
+﻿// DragonFruit.Common Copyright 2021 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace DragonFruit.Common.Data.Serializers
+{
+    public class SerializerResolver
+    {
+        private static Dictionary<Type, Type> DeserializerMap { get; } = new();
+        private static Dictionary<Type, Type> SerializerMap { get; } = new();
+
+        /// <summary>
+        /// Registers a serializer for the specified type. This applies to all <see cref="ApiClient"/>s
+        /// </summary>
+        /// <param name="direction">Whether this serializer should apply to incoming/outgoing data</param>
+        /// <typeparam name="T">The object type to specify the serializer for</typeparam>
+        /// <typeparam name="TSerializer">The serializer to apply</typeparam>
+        public static void Register<T, TSerializer>(DataDirection direction = DataDirection.All)
+            where T : class
+            where TSerializer : ISerializer
+        {
+            if (direction.HasFlag(DataDirection.In))
+            {
+                DeserializerMap[typeof(T)] = typeof(TSerializer);
+            }
+
+            if (direction.HasFlag(DataDirection.Out))
+            {
+                SerializerMap[typeof(T)] = typeof(TSerializer);
+            }
+        }
+
+        /// <summary>
+        /// Removes the registered serializer for the type. This applies to all <see cref="ApiClient"/>s
+        /// </summary>
+        /// <param name="direction">Whether this serializer should be removed from incoming/outgoing data</param>
+        /// <typeparam name="T">The object type to remove the serializer for</typeparam>
+        public static void Unregister<T>(DataDirection direction = DataDirection.All)
+            where T : class
+        {
+            if (direction.HasFlag(DataDirection.In))
+            {
+                DeserializerMap.Remove(typeof(T));
+            }
+
+            if (direction.HasFlag(DataDirection.Out))
+            {
+                SerializerMap.Remove(typeof(T));
+            }
+        }
+
+        public ISerializer Default { get; set; }
+        private ConcurrentDictionary<Type, ISerializer> SerializerCache { get; } = new();
+
+        /// <summary>
+        /// Resolves the <see cref="ISerializer"/> for the type provided
+        /// </summary>
+        /// <typeparam name="T">The type to resolve</typeparam>
+        public ISerializer Resolve<T>(DataDirection direction) where T : class => Resolve(typeof(T), direction);
+
+        /// <summary>
+        /// Resolves the <see cref="ISerializer"/> for the type provided
+        /// </summary>
+        public ISerializer Resolve(Type objectType, DataDirection direction)
+        {
+            if (!objectType.IsClass)
+            {
+                throw new ArgumentException("Provided object type is not a class", nameof(objectType));
+            }
+
+            var mapping = direction switch
+            {
+                DataDirection.In => DeserializerMap,
+                DataDirection.Out => SerializerMap,
+
+                _ => throw new ArgumentException(nameof(direction))
+            };
+
+            // if the map has the type registered, check the type in cache
+            if (mapping.TryGetValue(objectType, out var serializerType))
+            {
+                return SerializerCache.GetOrAdd(serializerType, _ => (ISerializer)Activator.CreateInstance(serializerType));
+            }
+
+            // use generic
+            return Default;
+        }
+
+        /// <summary>
+        /// Configures the specified <see cref="TSerializer"/>, creating a client-specific instance if needed
+        /// </summary>
+        /// <param name="options">The options to set</param>
+        /// <typeparam name="TSerializer">The <see cref="ISerializer"/> to configure</typeparam>
+        public void Configure<TSerializer>(Action<TSerializer> options) where TSerializer : ISerializer
+        {
+            if (Default.GetType() == typeof(TSerializer))
+            {
+                options?.Invoke((TSerializer)Default);
+            }
+            else
+            {
+                var serializer = SerializerCache.GetOrAdd(typeof(TSerializer), _ => Activator.CreateInstance<TSerializer>());
+                options?.Invoke((TSerializer)serializer);
+            }
+        }
+    }
+
+    public enum DataDirection
+    {
+        /// <summary>
+        /// Applies to incoming data (deserialization)
+        /// </summary>
+        In,
+
+        /// <summary>
+        /// Applies to outgoing data (serialization)
+        /// </summary>
+        Out,
+
+        /// <summary>
+        /// Applies to all data directions
+        /// </summary>
+        All = In | Out
+    }
+}

--- a/DragonFruit.Common.Data/Serializers/SerializerResolver.cs
+++ b/DragonFruit.Common.Data/Serializers/SerializerResolver.cs
@@ -102,10 +102,14 @@ namespace DragonFruit.Common.Data.Serializers
             {
                 options?.Invoke((TSerializer)Default);
             }
-            else
+            else if (DeserializerMap.ContainsValue(typeof(TSerializer)) || SerializerMap.ContainsValue(typeof(TSerializer)))
             {
                 var serializer = SerializerCache.GetOrAdd(typeof(TSerializer), _ => Activator.CreateInstance<TSerializer>());
                 options?.Invoke((TSerializer)serializer);
+            }
+            else
+            {
+                throw new ArgumentException("The specified serializer was not registered anywhere. It needs to be registered or set as the default before configuration can occur", nameof(TSerializer));
             }
         }
     }


### PR DESCRIPTION
### Overview
This allows for specialised serializers to be used. consider the case where a user wants to be able to read both Html and Json, but only wants one client. Previously that was not possible, but is now:

### Usage
The usage is simple. A user can define global overrides on a per-type basis. for example, if a user wants to deserialze a `HtmlDocument` with a `ApiHtmlSerializer`:

```cs
SerializerResolver.Register<HtmlDocument, ApiHtmlSerializer>(DataDirection.In);
```

> This will create the association for all `ApiClient`s when deserializing against this class. The datadirection is defaults to both directions but as in the example, can be customised.

When the user runs a perform where the output type is `HtmlDocument`, the `ApiHtmlSerializer` will be used, but for another object, i.e. `JObject`, the `ApiJsonSerializer` will be used, or whatever the default is at the time.

Customisation for serializers is done on a per-client basis, and if the serializer is not found, it is created. This can be done in the constructor as before:
```cs
client.Serializer.Configure<ApiHtmlSerializer>(o =>
{
    o.AutoDetectEncoding = false;
    o.Encoding = Encoding.Unicode;
});
```
> This sets the `ApiHtmlSerializer` to use Unicode as the encoding type and disables auto recognition

### Breaking changes
- Serializers will now need parameterless ctors, which means that users will need to use the configure function
- `ISerializer` is going to be replaced with `ApiSerializer` (base class)
