### PR TITLE
update default serializers to use new methods

### DIFF
--- a/DragonFruit.Common.Data.Tests/Serializer/SerializerResolverTests.cs
+++ b/DragonFruit.Common.Data.Tests/Serializer/SerializerResolverTests.cs
@@ -61,6 +61,7 @@ namespace DragonFruit.Common.Data.Tests.Serializer
     public class DummySerializer : ApiSerializer
     {
         public override string ContentType => "nothing";
+        public override bool IsGeneric => true;
 
         public override HttpContent Serialize<T>(T input) where T : class => throw new System.NotImplementedException();
         public override T Deserialize<T>(Stream input) where T : class => throw new System.NotImplementedException();

--- a/DragonFruit.Common.Data/Serializers/ApiJsonSerializer.cs
+++ b/DragonFruit.Common.Data/Serializers/ApiJsonSerializer.cs
@@ -85,7 +85,7 @@ namespace DragonFruit.Common.Data.Serializers
                 Serializer.Serialize(jsonWriter, input);
             }
 
-            return SerializerUtils.ProcessStream(this, stream);
+            return GetHttpContent(stream);
         }
 
         public override T Deserialize<T>(Stream input) where T : class

--- a/DragonFruit.Common.Data/Serializers/ApiSerializer.cs
+++ b/DragonFruit.Common.Data/Serializers/ApiSerializer.cs
@@ -23,6 +23,14 @@ namespace DragonFruit.Common.Data.Serializers
         public abstract string ContentType { get; }
 
         /// <summary>
+        /// Whether this <see cref="ApiSerializer"/> is generic (meaning any class can be serialized to/from).
+        /// </summary>
+        /// <remarks>
+        /// Setting this to <c>false</c> will throw an exception if the serializer is set as a default in a client.
+        /// </remarks>
+        public virtual bool IsGeneric => true;
+
+        /// <summary>
         /// Gets or sets the encoding the <see cref="ApiSerializer"/> uses
         /// </summary>
         public Encoding Encoding

--- a/DragonFruit.Common.Data/Serializers/ApiXmlSerializer.cs
+++ b/DragonFruit.Common.Data/Serializers/ApiXmlSerializer.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Xml.Serialization;
-using DragonFruit.Common.Data.Utils;
 
 namespace DragonFruit.Common.Data.Serializers
 {
@@ -34,7 +33,7 @@ namespace DragonFruit.Common.Data.Serializers
                 new XmlSerializer(typeof(T)).Serialize(writer, input);
             }
 
-            return SerializerUtils.ProcessStream(this, stream);
+            return GetHttpContent(stream);
         }
 
         public override T Deserialize<T>(Stream input) where T : class


### PR DESCRIPTION
also adds an overridable property that can block a serializer being used as the default (useful for single-type serializers)