### PR TITLE
Update ApiClient to expose less ctors

### DIFF
--- a/DragonFruit.Common.Data/ApiClient.cs
+++ b/DragonFruit.Common.Data/ApiClient.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using DragonFruit.Common.Data.Exceptions;
 using DragonFruit.Common.Data.Headers;
@@ -341,7 +340,7 @@ namespace DragonFruit.Common.Data
             {
                 // exit the read lock as soon as the request has been sent and processed
                 // this is because the callback could involve re-processing the request.
-                RequestFinished();
+                _lock.ExitReadLock();
             }
 
             try
@@ -403,25 +402,6 @@ namespace DragonFruit.Common.Data
             else
             {
                 Interlocked.CompareExchange(ref _clientAdjustmentRequestSignal, 1, 0);
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected void RequestFinished() => _lock.ExitReadLock();
-    }
-
-    /// <summary>
-    /// A <see cref="ApiClient"/> superclass designed to allow better serializer configuration
-    /// </summary>
-    /// <typeparam name="T">The <see cref="ApiSerializer"/> to use</typeparam>
-    public class ApiClient<T> : ApiClient where T : ApiSerializer, new()
-    {
-        public ApiClient(Action<T> configurationOptions = null)
-            : base(Activator.CreateInstance<T>())
-        {
-            if (configurationOptions != null)
-            {
-                Serializer.Configure(configurationOptions);
             }
         }
     }

--- a/DragonFruit.Common.Data/Serializers/SerializerResolver.cs
+++ b/DragonFruit.Common.Data/Serializers/SerializerResolver.cs
@@ -14,7 +14,6 @@ namespace DragonFruit.Common.Data.Serializers
         private static readonly Dictionary<Type, Type> SerializerMap = new Dictionary<Type, Type>();
         private static readonly Dictionary<Type, Type> DeserializerMap = new Dictionary<Type, Type>();
 
-        private ISerializer _default;
         private readonly ConcurrentDictionary<Type, ApiSerializer> _serializerCache = new ConcurrentDictionary<Type, ApiSerializer>();
 
         /// <summary>
@@ -67,21 +66,9 @@ namespace DragonFruit.Common.Data.Serializers
         }
 
         /// <summary>
-        /// The default <see cref="ISerializer"/> to use
+        /// The default <see cref="ISerializer"/> in use.
         /// </summary>
-        public ISerializer Default
-        {
-            get => _default;
-            set
-            {
-                if (value is ApiSerializer { IsGeneric: false })
-                {
-                    throw new ArgumentException("The provided serializer is non-generic.");
-                }
-
-                _default = value;
-            }
-        }
+        public ISerializer Default { get; }
 
         /// <summary>
         /// Resolves the <see cref="ApiSerializer"/> for the type provided

--- a/DragonFruit.Common.Data/TargetTypedApiClient.cs
+++ b/DragonFruit.Common.Data/TargetTypedApiClient.cs
@@ -1,0 +1,24 @@
+﻿// DragonFruit.Common Copyright 2021 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System;
+using DragonFruit.Common.Data.Serializers;
+
+namespace DragonFruit.Common.Data
+{
+    /// <summary>
+    /// A <see cref="ApiClient"/> superclass designed to allow better serializer configuration
+    /// </summary>
+    /// <typeparam name="T">The <see cref="ApiSerializer"/> to use</typeparam>
+    public class ApiClient<T> : ApiClient where T : ApiSerializer, new()
+    {
+        public ApiClient(Action<T> configurationOptions = null)
+            : base(Activator.CreateInstance<T>())
+        {
+            if (configurationOptions != null)
+            {
+                Serializer.Configure(configurationOptions);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This combines both the parameterless and the `CultureInfo` ctor into a single one. Also adds a new class for creating an `ApiClient` with a specific serializer, in generic form:

```cs
var client = new ApiClient<ApiXmlSerializer>(o => o.Encoding = Encoding.UTF32);
```

This new Target-Typed class will allow developers to force a specific serializer, and prevent the end user from changing it