### PR TITLE
Request stream types

### DIFF
--- a/DragonFruit.Common.Data.Tests/Requests/StreamTests.cs
+++ b/DragonFruit.Common.Data.Tests/Requests/StreamTests.cs
@@ -1,0 +1,22 @@
+﻿// DragonFruit.Common Copyright 2021 DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace DragonFruit.Common.Data.Tests.Requests
+{
+    [TestFixture]
+    public class StreamTests : ApiTest
+    {
+        [Test]
+        public async Task TestStreamRequests()
+        {
+            var networkStream = await Client.PerformAsync<MemoryStream>("https://google.com");
+            var fileStream = await Client.PerformAsync<FileStream>("https://google.com");
+
+            Assert.AreEqual(networkStream.Length, fileStream.Length);
+        }
+    }
+}

--- a/DragonFruit.Common.Data/ApiClient.cs
+++ b/DragonFruit.Common.Data/ApiClient.cs
@@ -267,18 +267,22 @@ namespace DragonFruit.Common.Data
 
             using var stream = await response.Content.ReadAsStreamAsync();
 
-            // raw stream
-            if (typeof(T) == typeof(Stream))
+            if (typeof(Stream).IsAssignableFrom(typeof(T)))
             {
-                return stream as T;
-            }
+                Stream result;
 
-            // filestream temp file buffered to disk
-            if (typeof(T) == typeof(FileStream))
-            {
-                var fileStream = File.Create(Path.GetTempFileName(), 4096, FileOptions.Asynchronous | FileOptions.SequentialScan | FileOptions.DeleteOnClose);
-                await stream.CopyToAsync(fileStream);
-                return fileStream as T;
+                if (typeof(T) == typeof(Stream) && response.Content.Headers.ContentLength < 80000 || typeof(T) == typeof(MemoryStream))
+                {
+                    result = new MemoryStream();
+                }
+                else
+                {
+                    result = File.Create(Path.GetTempFileName(), 4096, FileOptions.Asynchronous | FileOptions.SequentialScan | FileOptions.DeleteOnClose);
+                }
+
+                await stream.CopyToAsync(result).ConfigureAwait(false);
+                result.Seek(0, SeekOrigin.Begin);
+                return result as T;
             }
 
             return Serializer.Resolve<T>(DataDirection.In).Deserialize<T>(stream);


### PR DESCRIPTION
Adds support for 3 new classes:

`FileStream` - buffers to disk and deletes on disposal
`MemoryStream` - buffers directly to memory (not recommended due to memory leak potential)
`Stream` - picks from either of the above options based on content-length header