### PR TITLE
add html serializer

### DIFF
--- a/DragonFruit.Data.sln
+++ b/DragonFruit.Data.sln
@@ -22,6 +22,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DragonFruit.Data.Serializer
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DragonFruit.Data.Common", "common\DragonFruit.Data.Common.csproj", "{7C169022-60C3-488D-9A67-C0E5A36DE2C8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DragonFruit.Data.Serializers.Html", "serializers\DragonFruit.Data.Serializers.Html\DragonFruit.Data.Serializers.Html.csproj", "{BE0F43F0-871B-4A6D-8F43-5AAECDA129C3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +46,10 @@ Global
 		{7C169022-60C3-488D-9A67-C0E5A36DE2C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7C169022-60C3-488D-9A67-C0E5A36DE2C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7C169022-60C3-488D-9A67-C0E5A36DE2C8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE0F43F0-871B-4A6D-8F43-5AAECDA129C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE0F43F0-871B-4A6D-8F43-5AAECDA129C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE0F43F0-871B-4A6D-8F43-5AAECDA129C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE0F43F0-871B-4A6D-8F43-5AAECDA129C3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,5 +59,6 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{0D9C70B4-99AD-4D0C-BD6B-8E2B02E82C66} = {5A8982CD-EEF9-4B9F-AF74-C8D45241E137}
+		{BE0F43F0-871B-4A6D-8F43-5AAECDA129C3} = {5A8982CD-EEF9-4B9F-AF74-C8D45241E137}
 	EndGlobalSection
 EndGlobal

--- a/serializers/DragonFruit.Data.Serializers.Html/ApiHtmlSerializer.cs
+++ b/serializers/DragonFruit.Data.Serializers.Html/ApiHtmlSerializer.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using System.Net.Http;
+using HtmlAgilityPack;
+
+namespace DragonFruit.Data.Serializers.Html
+{
+    public class ApiHtmlSerializer : ApiSerializer
+    {
+        public override string ContentType => "text/html";
+        public override bool IsGeneric => false;
+
+        public override HttpContent Serialize<T>(T input)
+        {
+            ValidateType<T>();
+
+            // html is usually larger than 80kb
+            var stream = GetStream(true);
+            (input as HtmlDocument)!.Save(stream, Encoding);
+
+            return GetHttpContent(stream);
+        }
+
+        public override T Deserialize<T>(Stream input)
+        {
+            ValidateType<T>();
+
+            var document = new HtmlDocument();
+            document.Load(input, Encoding, AutoDetectEncoding);
+
+            return document as T; // where T is validated as a HtmlDocument
+        }
+
+        private static void ValidateType<T>()
+        {
+            if (typeof(T) != typeof(HtmlDocument))
+            {
+                throw new ArgumentException($"Cannot process {typeof(T).Name}", nameof(T));
+            }
+        }
+
+        /// <summary>
+        /// Registers the <see cref="ApiHtmlSerializer"/> to resolve <see cref="HtmlDocument"/> objects
+        /// </summary>
+        public static void RegisterDefaults() => SerializerResolver.Register<HtmlDocument, ApiHtmlSerializer>();
+    }
+}

--- a/serializers/DragonFruit.Data.Serializers.Html/DragonFruit.Data.Serializers.Html.csproj
+++ b/serializers/DragonFruit.Data.Serializers.Html/DragonFruit.Data.Serializers.Html.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <PackageId>DragonFruit.Data.Serializers.Html</PackageId>
+        <Description>HTML parsing (through HTMLAgilityPack) for DragonFruit.Data</Description>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="HtmlAgilityPack" Version="1.11.39" />
+    </ItemGroup>
+
+    <Import Project="$(SolutionDir)res\DragonFruit.Data.Serializers.props" />
+
+</Project>


### PR DESCRIPTION
adds the `ApiHtmlSerializer` from the common-serializers project. Utf8Json will not be ported and will be removed due to the backend not being updated to work with newer versions of .net