### PR TITLE
add system.text.json serializer

### DIFF
--- a/DragonFruit.Data.sln
+++ b/DragonFruit.Data.sln
@@ -24,6 +24,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DragonFruit.Data.Common", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DragonFruit.Data.Serializers.Html", "serializers\DragonFruit.Data.Serializers.Html\DragonFruit.Data.Serializers.Html.csproj", "{BE0F43F0-871B-4A6D-8F43-5AAECDA129C3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DragonFruit.Data.Serializers.SystemJson", "serializers\DragonFruit.Data.Serializers.SystemJson\DragonFruit.Data.Serializers.SystemJson.csproj", "{72224F8B-EB2A-4CAF-B325-BC40704AD7DE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +52,10 @@ Global
 		{BE0F43F0-871B-4A6D-8F43-5AAECDA129C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BE0F43F0-871B-4A6D-8F43-5AAECDA129C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BE0F43F0-871B-4A6D-8F43-5AAECDA129C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{72224F8B-EB2A-4CAF-B325-BC40704AD7DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{72224F8B-EB2A-4CAF-B325-BC40704AD7DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72224F8B-EB2A-4CAF-B325-BC40704AD7DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{72224F8B-EB2A-4CAF-B325-BC40704AD7DE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -60,5 +66,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{0D9C70B4-99AD-4D0C-BD6B-8E2B02E82C66} = {5A8982CD-EEF9-4B9F-AF74-C8D45241E137}
 		{BE0F43F0-871B-4A6D-8F43-5AAECDA129C3} = {5A8982CD-EEF9-4B9F-AF74-C8D45241E137}
+		{72224F8B-EB2A-4CAF-B325-BC40704AD7DE} = {5A8982CD-EEF9-4B9F-AF74-C8D45241E137}
 	EndGlobalSection
 EndGlobal

--- a/serializers/DragonFruit.Data.Serializers.SystemJson/ApiSystemTextJsonSerializer.cs
+++ b/serializers/DragonFruit.Data.Serializers.SystemJson/ApiSystemTextJsonSerializer.cs
@@ -1,0 +1,33 @@
+﻿// DragonFruit.Data Copyright DragonFruit Network
+// Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
+
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace DragonFruit.Data.Serializers.SystemJson
+{
+    public class ApiSystemTextJsonSerializer : ApiSerializer, IAsyncSerializer
+    {
+        public override string ContentType => "application/json";
+
+        // System.Text.Json doesn't accept different encoding
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public JsonSerializerOptions SerializerOptions { get; set; }
+
+        public override HttpContent Serialize<T>(T input)
+        {
+            var stream = GetStream(false);
+            JsonSerializer.Serialize(stream, input, SerializerOptions);
+
+            return GetHttpContent(stream);
+        }
+
+        public override T Deserialize<T>(Stream input) => JsonSerializer.Deserialize<T>(input, SerializerOptions);
+
+        public Task<T> DeserializeAsync<T>(Stream input) where T : class => JsonSerializer.DeserializeAsync<T>(input, SerializerOptions).AsTask();
+    }
+}

--- a/serializers/DragonFruit.Data.Serializers.SystemJson/DragonFruit.Data.Serializers.SystemJson.csproj
+++ b/serializers/DragonFruit.Data.Serializers.SystemJson/DragonFruit.Data.Serializers.SystemJson.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <PackageId>DragonFruit.Data.Serializers.SystemJson</PackageId>
+        <Description>System.Text.Json serializer for DragonFruit.Data</Description>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="System.Text.Json" Version="6.0.1" />
+    </ItemGroup>
+
+    <Import Project="$(SolutionDir)res\DragonFruit.Data.Serializers.props" />
+
+</Project>

--- a/src/Serializers/ApiSerializer.cs
+++ b/src/Serializers/ApiSerializer.cs
@@ -39,7 +39,7 @@ namespace DragonFruit.Data.Serializers
         /// <summary>
         /// Gets or sets the encoding the <see cref="ApiSerializer"/> uses
         /// </summary>
-        public Encoding Encoding
+        public virtual Encoding Encoding
         {
             get => _encoding ?? Encoding.UTF8;
             set => _encoding = value;


### PR DESCRIPTION
adds the new system.text.json serializer that can now be used properly over the newtonsoft equivalent, supporting async deserialization.