### PR TITLE
Fix encoding issues

### DIFF
--- a/res/DragonFruit.Data.Nuget.props
+++ b/res/DragonFruit.Data.Nuget.props
@@ -11,12 +11,9 @@
         <RepositoryUrl>https://github.com/dragonfruitnetwork/dragonfruit.common</RepositoryUrl>
         <PackageProjectUrl>https://github.com/dragonfruitnetwork/dragonfruit.common</PackageProjectUrl>
     </PropertyGroup>
-    
+
     <ItemGroup>
-        <None Include="$(SolutionDir)res\icon.png">
-            <Pack>true</Pack>
-            <PackagePath>.</PackagePath>
-        </None>
+        <None Include="$(SolutionDir)res\icon.png" Pack="true" PackagePath="."/>
     </ItemGroup>
 
 </Project>

--- a/res/DragonFruit.Data.Serializers.props
+++ b/res/DragonFruit.Data.Serializers.props
@@ -1,8 +1,8 @@
 <Project>
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>8</LangVersion>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/serializers/DragonFruit.Data.Serializers.SystemJson/ApiSystemTextJsonSerializer.cs
+++ b/serializers/DragonFruit.Data.Serializers.SystemJson/ApiSystemTextJsonSerializer.cs
@@ -14,7 +14,15 @@ namespace DragonFruit.Data.Serializers.SystemJson
         private JsonSerializerOptions _serializerOptions;
 
         public override string ContentType => "application/json";
-        public override Encoding Encoding => Encoding.UTF8;
+
+        public override Encoding Encoding
+        {
+            get => base.Encoding;
+            set
+            {
+                // set should not do anything, as the serializer doesn't support non-utf8
+            }
+        }
 
         public JsonSerializerOptions SerializerOptions
         {

--- a/src/Serializers/ApiSerializer.cs
+++ b/src/Serializers/ApiSerializer.cs
@@ -41,7 +41,7 @@ namespace DragonFruit.Data.Serializers
         /// </summary>
         public virtual Encoding Encoding
         {
-            get => _encoding ?? Encoding.UTF8;
+            get => _encoding ??= new UTF8Encoding(false);
             set => _encoding = value;
         }
 


### PR DESCRIPTION
Now compliant with RFC 7159, Section 8.1:
> Implementations MUST NOT add a byte order mark to the beginning of a JSON text.

This change has been made against all serializers, because they use all start on UTF8, which is arguably the de-facto now.