### PR TITLE
add support for non-string enumerables

### DIFF
--- a/src/Utils/ParameterUtils.cs
+++ b/src/Utils/ParameterUtils.cs
@@ -45,7 +45,7 @@ namespace DragonFruit.Data.Utils
                 // check if the type we've got is an IEnumerable of anything AND we have a valid collection handler mode
                 if (attribute.CollectionHandling.HasValue && typeof(IEnumerable).IsAssignableFrom(property.PropertyType))
                 {
-                    Func<IEnumerable<object>, string, CultureInfo, IEnumerable<KeyValuePair<string, string>>> entityConverter = attribute.CollectionHandling switch
+                    Func<IEnumerable, string, CultureInfo, IEnumerable<KeyValuePair<string, string>>> entityConverter = attribute.CollectionHandling switch
                     {
                         CollectionConversionMode.Recursive => ApplyRecursiveConversion,
                         CollectionConversionMode.Unordered => ApplyUnorderedConversion,
@@ -55,7 +55,7 @@ namespace DragonFruit.Data.Utils
                         _ => throw new ArgumentOutOfRangeException()
                     };
 
-                    foreach (var entry in entityConverter.Invoke((IEnumerable<object>)propertyValue, keyName, culture))
+                    foreach (var entry in entityConverter.Invoke((IEnumerable)propertyValue, keyName, culture))
                         // we purposely keep nulls in here, as it might affect the ordering.
                     {
                         yield return entry;
@@ -102,17 +102,17 @@ namespace DragonFruit.Data.Utils
             return attributedProperty.GetValue(host);
         }
 
-        private static IEnumerable<KeyValuePair<string, string>> ApplyRecursiveConversion(IEnumerable<object> values, string keyName, CultureInfo culture)
+        private static IEnumerable<KeyValuePair<string, string>> ApplyRecursiveConversion(IEnumerable values, string keyName, CultureInfo culture)
         {
-            return values.Select(x => x.ToKeyValuePair(keyName, culture));
+            return values.Cast<object>().Select(x => x.ToKeyValuePair(keyName, culture));
         }
 
-        private static IEnumerable<KeyValuePair<string, string>> ApplyUnorderedConversion(IEnumerable<object> values, string keyName, CultureInfo culture)
+        private static IEnumerable<KeyValuePair<string, string>> ApplyUnorderedConversion(IEnumerable values, string keyName, CultureInfo culture)
         {
-            return values.Select(x => x.ToKeyValuePair($"{keyName}[]", culture));
+            return values.Cast<object>().Select(x => x.ToKeyValuePair($"{keyName}[]", culture));
         }
 
-        private static IEnumerable<KeyValuePair<string, string>> ApplyOrderedConversion(IEnumerable<object> values, string keyName, CultureInfo culture)
+        private static IEnumerable<KeyValuePair<string, string>> ApplyOrderedConversion(IEnumerable values, string keyName, CultureInfo culture)
         {
             var counter = 0;
             var enumerator = values.GetEnumerator();
@@ -122,12 +122,13 @@ namespace DragonFruit.Data.Utils
                 yield return enumerator.Current.ToKeyValuePair($"{keyName}[{counter++}]", culture);
             }
 
-            enumerator.Dispose();
+            // dispose if possible
+            (enumerator as IDisposable)?.Dispose();
         }
 
-        private static IEnumerable<KeyValuePair<string, string>> ApplyConcatenation(IEnumerable<object> values, string keyName, CultureInfo culture, string concatCharacter)
+        private static IEnumerable<KeyValuePair<string, string>> ApplyConcatenation(IEnumerable values, string keyName, CultureInfo culture, string concatCharacter)
         {
-            yield return new KeyValuePair<string, string>(keyName, string.Join(concatCharacter, values.Select(x => x.AsString(culture))));
+            yield return new KeyValuePair<string, string>(keyName, string.Join(concatCharacter, values.Cast<object>().Select(x => x.AsString(culture))));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/tests/Requests/RequestTests.cs
+++ b/tests/Requests/RequestTests.cs
@@ -1,10 +1,13 @@
 ﻿// DragonFruit.Data Copyright DragonFruit Network
 // Licensed under the MIT License. Please refer to the LICENSE file at the root of this project for details
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using DragonFruit.Data.Basic;
+using DragonFruit.Data.Parameters;
 using NUnit.Framework;
 
 namespace DragonFruit.Data.Tests.Requests
@@ -47,6 +50,26 @@ namespace DragonFruit.Data.Tests.Requests
 
             Assert.IsTrue(result.IsSuccessStatusCode);
             Assert.AreEqual(request.Version, result.Version);
+        }
+
+        [Test]
+        public void TestConcatEnumerable()
+        {
+            var req = new EnumerableTest(Enumerable.Range(1, 5));
+            Assert.True(req.FullUrl.Contains("1,2,3"));
+        }
+
+        private class EnumerableTest : ApiRequest
+        {
+            public override string Path => "https://example.com";
+
+            public EnumerableTest(IEnumerable<int> data)
+            {
+                Data = data;
+            }
+
+            [QueryParameter("data", CollectionConversionMode.Concatenated)]
+            public IEnumerable<int> Data { get; set; }
         }
     }
 }


### PR DESCRIPTION
Because non-string enumerables can't be casted to `IEnumerable<object>`, they would fail and produce an exception...
This adds support for that scenario, allowing `IEnumerable` to be converted to `IEnumerable<object>` to allow conversions to take place.